### PR TITLE
fix(dcp): add h1-typo

### DIFF
--- a/jenkins-dcp.planx-pla.net/portal/gitops.json
+++ b/jenkins-dcp.planx-pla.net/portal/gitops.json
@@ -34,7 +34,7 @@
     "appName": "NHLBI DataSTAGE",
     "index": {
       "introduction": {
-        "heading": "",
+        "heading": "DataSTAGE",
         "text": "DataSTAGE supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer. The data commons supports cross-project analyses by harmonizing data from different projects through the collaborative development of a data dictionary, providing an API for data queries and download, and providing a cloud-based analysis workspace with rich tools and resources.",
         "link": "/submission"
       },


### PR DESCRIPTION
Empty heading in the introduction causes `Login` integration test to fail