### PR TITLE
chore/mickey

### DIFF
--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -23,7 +23,7 @@
     "sheepdog": "quay.io/cdis/sheepdog:master",
     "spark": "quay.io/cdis/gen3-spark:master",
     "tube": "quay.io/cdis/tube:master",
-    "sower": "quay.io/cdis/sower:feat_configuration",
+    "sower": "quay.io/cdis/sower:0.1.0",
     "ssjdispatcher": "quay.io/cdis/ssjdispatcher:master"
   },
   "arborist": {


### PR DESCRIPTION
The latest supported `sower` version is `0.1.0` for Mickey.