### PR TITLE
Revert some qa-anvil manifest changes from e7c5697

### DIFF
--- a/qa-anvil.planx-pla.net/manifest.json
+++ b/qa-anvil.planx-pla.net/manifest.json
@@ -30,8 +30,8 @@
     "dashboard": "quay.io/cdis/gen3-statics:master"
   },
   "global": {
-    "environment": "anvilstaging",
-    "hostname": "staging.theanvil.io",
+    "environment": "qaplanetv1",
+    "hostname": "qa-anvil.planx-pla.net",
     "revproxy_arn": "arn:aws:acm:us-east-1:474789003679:certificate/9fd731e3-3366-4bd0-a3ef-0453dc07289a",
     "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/anvil/1.0.4/schema.json",
     "portal_app": "gitops",
@@ -39,7 +39,7 @@
     "logs_bucket": "logs-anvilstaging-gen3",
     "netpolicy": "on",
     "sync_from_dbgap": "False",
-    "useryaml_s3path": "s3://cdis-gen3-users/anvilstaging/user.yaml",
+    "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "10",
     "tier_access_level": "regular",
     "tier_access_limit": 50,


### PR DESCRIPTION
* This commit reverts some changes made to qa-anvil's manifest in e7c5697,
  which caused issues when gen3 users tried to authenticate with qa-anvil.
  Specifically, `useryaml_s3path` was changed to anvil-staging's useryaml.
  This commit also reverts changes to other properties that were set to
  anvil-staging's values.