### PR TITLE
chore(kfqa): update for centralized auth

### DIFF
--- a/qa-kidsfirst.planx-pla.net/manifest.json
+++ b/qa-kidsfirst.planx-pla.net/manifest.json
@@ -7,15 +7,15 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:1.2.0",
+    "arborist": "quay.io/cdis/arborist:2.3.2",
     "dashboard": "quay.io/cdis/gen3-statics:1.0.0",
-    "fence": "quay.io/cdis/fence:2.8.2",
-    "indexd": "quay.io/cdis/indexd:1.0.9",
-    "peregrine": "quay.io/cdis/peregrine:1.2.1",
-    "pidgin": "quay.io/cdis/pidgin:1.0.0",
+    "fence": "quay.io/cdis/fence:4.8.0",
+    "indexd": "quay.io/cdis/indexd:2.5.0",
+    "peregrine": "quay.io/cdis/peregrine:2.1.1",
+    "pidgin": "quay.io/cdis/pidgin:1.2.0",
     "revproxy": "quay.io/cdis/nginx:1.15.5-ctds",
-    "sheepdog": "quay.io/cdis/sheepdog:1.1.11",
-    "portal": "quay.io/cdis/data-portal:2.2.1",
+    "sheepdog": "quay.io/cdis/sheepdog:2.1.2",
+    "portal": "quay.io/cdis/data-portal:2.22.10",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master"
   },


### PR DESCRIPTION
latest services except fence, use 4.8.0 which is pre-c999 fix