### PR TITLE
(PXP-3380) Change default jupyterhub directory to `pd`

### DIFF
--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -103,7 +103,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -118,7 +118,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"

--- a/qa-bloodpac.planx-pla.net/manifest.json
+++ b/qa-bloodpac.planx-pla.net/manifest.json
@@ -75,7 +75,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"
@@ -102,7 +104,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"

--- a/qa-brain.planx-pla.net/manifest.json
+++ b/qa-brain.planx-pla.net/manifest.json
@@ -99,7 +99,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"
@@ -126,7 +128,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"

--- a/qa-brain.planx-pla.net/manifest.json
+++ b/qa-brain.planx-pla.net/manifest.json
@@ -70,7 +70,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"

--- a/qa-dcfdemo.planx-pla.net/manifest.json
+++ b/qa-dcfdemo.planx-pla.net/manifest.json
@@ -82,7 +82,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"
@@ -109,7 +111,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -150,7 +150,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"
@@ -177,7 +179,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"
@@ -204,7 +208,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"
@@ -230,7 +236,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"
@@ -256,7 +264,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"

--- a/qa-nde.planx-pla.net/manifest.json
+++ b/qa-nde.planx-pla.net/manifest.json
@@ -68,7 +68,13 @@
       "name": "Jupyter Notebook Bio Python",
       "image": "quay.io/occ_data/jupyternotebook:fix_niaid-test",
       "env": {"FRAME_ANCESTORS": "https://qa-tb.planx-pla.net https://qa-microbiome.planx-pla.net https://qa-aids.planx-pla.net https://qa-flu.planx-pla.net"},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.password=''","--NotebookApp.token=''"],
+      "args": [
+        "--NotebookApp.base_url=/lw-workspace/proxy/",
+        "--NotebookApp.password=''",
+        "--NotebookApp.token=''",
+        "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+        "--NotebookApp.quit_button=False"
+      ],
       "command": ["start-notebook.sh"],
       "path-rewrite": "/lw-workspace/proxy/",
       "use-tls": "false",
@@ -86,7 +92,13 @@
       "name": "Jupyter Notebook- TB Ariba and Mykrobe (Lab Edition)",
       "image": "quay.io/cdis/jupyter-tb:chore_nde_base",
       "env": {"FRAME_ANCESTORS": "https://qa-tb.planx-pla.net https://qa-microbiome.planx-pla.net https://qa-aids.planx-pla.net https://qa-flu.planx-pla.net"},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.default_url=/lab","--NotebookApp.password=''","--NotebookApp.token=''"],
+      "args": [
+        "--NotebookApp.base_url=/lw-workspace/proxy/",
+        "--NotebookApp.password=''",
+        "--NotebookApp.token=''",
+        "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+        "--NotebookApp.quit_button=False"
+      ],
       "command": ["start-notebook.sh"],
       "path-rewrite": "/lw-workspace/proxy/",
       "use-tls": "false",
@@ -104,7 +116,13 @@
       "name": "Jupyter Notebook- DAIDS (Lab Edition)",
       "image": "quay.io/cdis/jupyter-daids:chore_nde_base",
       "env": {"FRAME_ANCESTORS": "https://qa-tb.planx-pla.net https://qa-microbiome.planx-pla.net https://qa-aids.planx-pla.net https://qa-flu.planx-pla.net"},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.default_url=/lab","--NotebookApp.password=''","--NotebookApp.token=''"],
+      "args": [
+        "--NotebookApp.base_url=/lw-workspace/proxy/",
+        "--NotebookApp.password=''",
+        "--NotebookApp.token=''",
+        "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+        "--NotebookApp.quit_button=False"
+      ],
       "command": ["start-notebook.sh"],
       "path-rewrite": "/lw-workspace/proxy/",
       "use-tls": "false",
@@ -122,7 +140,13 @@
       "name": "Jupyter Notebook- DAIT (Lab Edition)",
       "image": "quay.io/cdis/jupyter-dait:chore_nde_base",
       "env": {"FRAME_ANCESTORS": "https://qa-tb.planx-pla.net https://qa-microbiome.planx-pla.net https://qa-aids.planx-pla.net https://qa-flu.planx-pla.net"},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.default_url=/lab","--NotebookApp.password=''","--NotebookApp.token=''"],
+      "args": [
+        "--NotebookApp.base_url=/lw-workspace/proxy/",
+        "--NotebookApp.password=''",
+        "--NotebookApp.token=''",
+        "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+        "--NotebookApp.quit_button=False"
+      ],
       "command": ["start-notebook.sh"],
       "path-rewrite": "/lw-workspace/proxy/",
       "use-tls": "false",
@@ -140,7 +164,13 @@
       "name": "Jupyter Notebook- DMID (Lab Edition)",
       "image": "quay.io/cdis/jupyter-dmid:chore_nde_base",
       "env": {"FRAME_ANCESTORS": "https://qa-tb.planx-pla.net https://qa-microbiome.planx-pla.net https://qa-aids.planx-pla.net https://qa-flu.planx-pla.net"},
-      "args": ["--NotebookApp.base_url=/lw-workspace/proxy/","--NotebookApp.default_url=/lab","--NotebookApp.password=''","--NotebookApp.token=''"],
+      "args": [
+        "--NotebookApp.base_url=/lw-workspace/proxy/",
+        "--NotebookApp.password=''",
+        "--NotebookApp.token=''",
+        "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+        "--NotebookApp.quit_button=False"
+      ],
       "command": ["start-notebook.sh"],
       "path-rewrite": "/lw-workspace/proxy/",
       "use-tls": "false",

--- a/qa-test1.planx-pla.net/manifest.json
+++ b/qa-test1.planx-pla.net/manifest.json
@@ -110,7 +110,9 @@
         "args": [
           "--NotebookApp.base_url=/lw-workspace/proxy/",
           "--NotebookApp.password=''",
-          "--NotebookApp.token=''"
+          "--NotebookApp.token=''",
+          "--NotebookApp.notebook_dir='/home/jovyan/pd'",
+          "--NotebookApp.quit_button=False"
         ],
         "command": [
           "start-notebook.sh"


### PR DESCRIPTION
This PR resolves https://ctds-planx.atlassian.net/browse/PXP-3380 in QA environments with Hatchery and Jupyterhub containers. Previously, users saved some work outside of persistent folders and were surprised when their files were lose. The containers can now _only_ access the persistent `pd` folder.

This PR also fixes another small UX issue by removing the `Quit` button from Jupyterhub containers -- pressing this Quit button would result in confusing behavior as the notebook shut down but the container would still be running. We want users to shut down their notebooks using the `Terminate Workspace` button in the explorer.