### PR TITLE
chore(qa): Updating dictionary for jenkins-dcp

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('cdis-jenkins-lib@chore/some_github_label_magic') _
+@Library('cdis-jenkins-lib@master') _
 testPipeline {
   MANIFEST = "True"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('cdis-jenkins-lib@master') _
+@Library('cdis-jenkins-lib@chore/some_github_label_magic') _
 testPipeline {
   MANIFEST = "True"
 }

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -62,7 +62,7 @@
     "environment": "qaplanetv1",
     "hostname": "jenkins-dcp.planx-pla.net",
     "revproxy_arn": "arn:aws:acm:us-east-1:707767160287:certificate/c676c81c-9546-4e9a-9a72-725dd3912bc8",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.2.4/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.3.8/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-qaplanetv1-gen3",
     "logs_bucket": "logs-qaplanetv1-gen3",


### PR DESCRIPTION
Tests in `jenkins-dcp` have been failing due to changes related to "case" vs. "subject" terminology.
This dictionary update should address this issue.

Error msgs:
```
ERR: "case" does not exist
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! cloud_portal@0.1.0 sanity-check: `node ./sanity-check`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the cloud_portal@0.1.0 sanity-check script.
? `ERR: "case" does not exist
```
and
```
Error: /data-portal/src/gqlHelper.js: Relay Transform Error: You supplied a field named `_subject_count` on type `Root`, but no such field exists on that type.
  17 |    * Fetch the initial list of projects and global node counts
  18 |    */
> 19 |   homepageQuery: graphql`query gqlHelperHomepageQuery {
     |                  ^
  20 |     projectList: project(first: 10000) {
  21 |       name: project_id
  22 |       code
```