### PR TITLE
Update qa-dcp dictionary to v.3.3.10

### DIFF
--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -131,7 +131,7 @@
     "environment": "qaplanetv1",
     "hostname": "qa-dcp.planx-pla.net",
     "revproxy_arn": "arn:aws:acm:us-east-1:707767160287:certificate/c676c81c-9546-4e9a-9a72-725dd3912bc8",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.3.7/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/3.3.10/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-qaplanetv1-gen3",
     "logs_bucket": "logs-qaplanetv1-gen3",


### PR DESCRIPTION
For PXP-5078 (Sensitive study exclusion for BioData Catalyst) https://ctds-planx.atlassian.net/browse/PXP-5078
- Updates qa-dcp to use dictionary with support for sensitive study exclusion field on the `study` node (The field is `study.excludeFromAggregations`)

