### PR TITLE
fix(qa): fix guppy indexing config

### DIFF
--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -151,11 +151,11 @@
   "guppy": {
     "indices": [
       {
-        "index": "qa-dcp_etl_49",
-        "type": "case"
+        "index": "qa-dcp_etl",
+        "type": "subject"
       },
       {
-        "index": "qa-dcp_file_23",
+        "index": "qa-dcp_file",
         "type": "file"
       }
     ],


### PR DESCRIPTION
reverting guppy indexing config to use "subject" to unblock release testing.