### PR TITLE
fix(qa): Unblock the pipeline by setting backup ES indices

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -93,11 +93,11 @@
   "guppy": {
     "indices": [
       {
-        "index": "qa-dcp_etl_49",
+        "index": "qa-dcp_etl_47",
         "type": "case"
       },
       {
-        "index": "qa-dcp_file_23",
+        "index": "qa-dcp_file_22",
         "type": "file"
       }
     ],

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -90,11 +90,11 @@
   "guppy": {
     "indices": [
       {
-        "index": "qa-dcp_etl_49",
+        "index": "qa-dcp_etl_47",
         "type": "case"
       },
       {
-        "index": "qa-dcp_file_23",
+        "index": "qa-dcp_file_22",
         "type": "file"
       }
     ],

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -83,11 +83,11 @@
   "guppy": {
     "indices": [
       {
-        "index": "qa-dcp_etl_49",
+        "index": "qa-dcp_etl_47",
         "type": "case"
       },
       {
-        "index": "qa-dcp_file_23",
+        "index": "qa-dcp_file_22",
         "type": "file"
       }
     ],

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -94,11 +94,11 @@
   "guppy": {
     "indices": [
       {
-        "index": "qa-dcp_etl_49",
+        "index": "qa-dcp_etl_47",
         "type": "case"
       },
       {
-        "index": "qa-dcp_file_23",
+        "index": "qa-dcp_file_22",
         "type": "file"
       }
     ],

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -92,11 +92,11 @@
   "guppy": {
     "indices": [
       {
-        "index": "qa-dcp_etl_49",
+        "index": "qa-dcp_etl_47",
         "type": "case"
       },
       {
-        "index": "qa-dcp_file_23",
+        "index": "qa-dcp_file_22",
         "type": "file"
       }
     ],


### PR DESCRIPTION
Pipeline is blocked due to Elastic Search indices that were deleted during an experiment in qa-dcp earlier today. These backup indices seem to be working fine so we should adopt them to unblock the CI pipeline.

I've applied them in jenkins-dcp  and ran a quick test:
```
gen3-qa [master●] % GEN3_SKIP_PROJ_SETUP=true 
RUNNING_LOCAL=true 
NAMESPACE="jenkins-dcp" 
npm test -- --verbose suites/guppy/guppyTest.js
```
result:
`OK  | 7 passed   // 38s`