### PR TITLE
chore(qa): min 3 presigned-url-fence pods to support the CI pipeline tests

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -115,7 +115,10 @@
       "strategy": "auto"
     },
     "presigned-url-fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 3,
+      "max": 5,
+      "targetCpu": 40
     },
     "indexd": {
       "strategy": "auto"

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -112,7 +112,10 @@
       "strategy": "auto"
     },
     "presigned-url-fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 3,
+      "max": 5,
+      "targetCpu": 40
     },
     "indexd": {
       "strategy": "auto"

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -105,7 +105,10 @@
       "strategy": "auto"
     },
     "presigned-url-fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 3,
+      "max": 5,
+      "targetCpu": 40
     },
     "indexd": {
       "strategy": "auto"

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -116,7 +116,10 @@
       "strategy": "auto"
     },
     "presigned-url-fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 3,
+      "max": 5,
+      "targetCpu": 40
     },
     "indexd": {
       "strategy": "auto"

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -114,7 +114,10 @@
       "strategy": "auto"
     },
     "presigned-url-fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 3,
+      "max": 5,
+      "targetCpu": 40
     },
     "indexd": {
       "strategy": "auto"


### PR DESCRIPTION
Seeing some API rate limiting responses while running presigned url tests:
```
      › [Response] Response error. Status code: 503
      › [Response] {"error":"service failure - try again later"}
```