### PR TITLE
chore(qa): Update sower config with sower-jobs-g3auto secrets

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -44,6 +44,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -61,10 +62,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -72,9 +73,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],
@@ -83,6 +84,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",
@@ -100,10 +102,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -111,9 +113,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],

--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -44,7 +44,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-blood-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -84,7 +84,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-blood-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -43,6 +43,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -60,10 +61,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -71,9 +72,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],
@@ -82,6 +83,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",
@@ -99,10 +101,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -110,9 +112,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -43,7 +43,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-brain-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -83,7 +83,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-brain-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -39,6 +39,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -56,10 +57,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -67,9 +68,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],
@@ -78,6 +79,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",
@@ -95,10 +97,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -106,9 +108,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -39,7 +39,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -79,7 +79,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -58,7 +58,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-genomel-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -98,7 +98,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-genomel-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -58,6 +58,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -75,10 +76,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -86,9 +87,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],
@@ -97,6 +98,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",
@@ -114,10 +116,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -125,9 +127,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -59,6 +59,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -76,10 +77,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -87,9 +88,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],
@@ -98,6 +99,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
+      "serviceAccountName": "jobs-${hostname//./-}",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",
@@ -115,10 +117,10 @@
         ],
         "volumeMounts": [
           {
-            "name": "manifest-indexing-creds-volume",
+            "name": "sower-jobs-creds-volume",
             "readOnly": true,
-            "mountPath": "/manifest-indexing-creds.json",
-            "subPath": "config.json"
+            "mountPath": "/creds.json",
+            "subPath": "creds.json"
           }
         ],
         "cpu-limit": "1",
@@ -126,9 +128,9 @@
       },
       "volumes": [
         {
-          "name": "manifest-indexing-creds-volume",
+          "name": "sower-jobs-creds-volume",
           "secret": {
-            "secretName": "manifestindexing-g3auto"
+            "secretName": "sower-jobs-g3auto"
           }
         }
       ],

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -59,7 +59,7 @@
     {
       "name": "manifest-indexing",
       "action": "index-object-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-niaid-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/manifest-indexing:master",
@@ -99,7 +99,7 @@
     {
       "name": "indexd-manifest",
       "action": "download-indexd-manifest",
-      "serviceAccountName": "jobs-${hostname//./-}",
+      "serviceAccountName": "jobs-jenkins-niaid-planx-pla-net",
       "container": {
         "name": "job-task",
         "image": "quay.io/cdis/download-indexd-manifest:master",


### PR DESCRIPTION
This config is required to run new automated E2E tests for Indexing GUI & manifest indexing sower jobs.

Based on these instructions:
https://github.com/uc-cdis/sower-jobs/blob/master/README.md#indexing-manifest