### PR TITLE
covid19 explorer files tab

### DIFF
--- a/qa-covid19.planx-pla.net/etlMapping.yaml
+++ b/qa-covid19.planx-pla.net/etlMapping.yaml
@@ -77,7 +77,6 @@ mappings:
     root: None
     category: data_file
     props:
-      - name: project_id
       - name: object_id
       - name: md5sum
       - name: file_name

--- a/qa-covid19.planx-pla.net/etlMapping.yaml
+++ b/qa-covid19.planx-pla.net/etlMapping.yaml
@@ -77,6 +77,7 @@ mappings:
     root: None
     category: data_file
     props:
+      - name: project_id
       - name: object_id
       - name: md5sum
       - name: file_name

--- a/qa-covid19.planx-pla.net/portal/gitops.json
+++ b/qa-covid19.planx-pla.net/portal/gitops.json
@@ -142,9 +142,9 @@
       "table": {
         "enabled": true,
         "fields": [
+          "code",
           "name",
-          "data_description",
-          "code"
+          "data_description"
         ]
       },
       "buttons": [],
@@ -156,10 +156,7 @@
           { "field": "code", "name": "ID" }
         ],
         "manifestMapping": {
-          "resourceIndexType": "file",
-          "resourceIdField": "object_id",
-          "referenceIdFieldInResourceIndex": "subject_id",
-          "referenceIdFieldInDataIndex": "node_id"
+          "referenceIdFieldInResourceIndex": "code"
         }
       }
     },
@@ -218,11 +215,75 @@
           { "field": "project_id", "name": "Dataset" }
         ],
         "manifestMapping": {
-          "resourceIndexType": "file",
-          "resourceIdField": "object_id",
-          "referenceIdFieldInResourceIndex": "subject_id",
-          "referenceIdFieldInDataIndex": "node_id"
+          "referenceIdFieldInResourceIndex": "subject_id"
         }
+      }
+    },
+    {
+      "tabTitle": "Genomics",
+      "charts": {
+        "data_type": {
+          "chartType": "bar",
+          "title": "File Type"
+        },
+        "data_format": {
+          "chartType": "bar",
+          "title": "File Format"
+        }
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "File",
+            "fields": [
+              "project_id",
+              "data_type",
+              "data_format"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "file_name",
+          "file_size",
+          "object_id"
+        ]
+      },
+      "dropdowns": {},
+      "buttons": [
+        {
+          "enabled": true,
+          "type": "file-manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "file-manifest.json",
+          "dropdownId": "download"
+        },
+        {
+          "enabled": false,
+          "type": "export-files-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          { "field": "object_id", "name": "GUID" },
+          { "field": "project_id", "name": "Dataset" }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "referenceIdFieldInResourceIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
       }
     }
   ],

--- a/qa-covid19.planx-pla.net/portal/gitops.json
+++ b/qa-covid19.planx-pla.net/portal/gitops.json
@@ -236,7 +236,6 @@
           {
             "title": "File",
             "fields": [
-              "project_id",
               "data_type",
               "data_format"
             ]
@@ -275,14 +274,14 @@
         "dataType": "file",
         "fieldMapping": [
           { "field": "object_id", "name": "GUID" },
-          { "field": "project_id", "name": "Dataset" }
+          { "field": "project_id", "name": "Dataset" },
+          { "field": "data_type", "name": "File Type" },
+          { "field": "data_format", "name": "File Format" }
         ],
         "nodeCountTitle": "Files",
         "manifestMapping": {
           "referenceIdFieldInResourceIndex": "object_id"
         },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id",
         "downloadAccessor": "object_id"
       }
     }


### PR DESCRIPTION
`project_id` filter disabled until further investigation because it makes the page crash in QA