### PR TITLE
chore: update the services to 2020.05

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -4,25 +4,25 @@
     "That's all I have to say"
   ],
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.03",
+    "arborist": "quay.io/cdis/arborist:2020.05",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "covid19-etl": "quay.io/cdis/covid19-etl:1.0.11",
     "nb-etl": "quay.io/cdis/nb-etl:1.0.11",
-    "fence": "quay.io/cdis/fence:2020.03",
-    "indexd": "quay.io/cdis/indexd:2020.03",
-    "peregrine": "quay.io/cdis/peregrine:2020.03",
-    "pidgin": "quay.io/cdis/pidgin:2020.03",
+    "fence": "quay.io/cdis/fence:2020.05",
+    "indexd": "quay.io/cdis/indexd:2020.05",
+    "peregrine": "quay.io/cdis/peregrine:2020.05",
+    "pidgin": "quay.io/cdis/pidgin:2020.05",
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
     "sheepdog": "quay.io/cdis/sheepdog:4.1.0",
     "portal": "quay.io/cdis/data-portal:covid19-3.1.0",
-    "tube": "quay.io/cdis/tube:0.3.28",
+    "tube": "quay.io/cdis/tube:2020.05",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "quay.io/cdis/gen3-spark:2020.03",
-    "hatchery": "quay.io/cdis/hatchery:2020.03",
-    "wts": "quay.io/cdis/workspace-token-service:2020.03",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.03",
+    "spark": "quay.io/cdis/gen3-spark:2020.05",
+    "hatchery": "quay.io/cdis/hatchery:2020.05",
+    "wts": "quay.io/cdis/workspace-token-service:2020.05",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.05",
     "ambassador": "quay.io/datawire/ambassador:0.60.3",
-    "guppy": "quay.io/cdis/guppy:0.4.2",
+    "guppy": "quay.io/cdis/guppy:2020.05",
     "dashboard": "quay.io/cdis/gen3-statics:1.0.0"
   },
   "global": {
@@ -51,7 +51,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2020.03"
+      "indexing": "quay.io/cdis/indexs3client:2020.05"
     }
   },
   "guppy": {

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -15,7 +15,7 @@
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
     "sheepdog": "quay.io/cdis/sheepdog:4.1.0",
     "portal": "quay.io/cdis/data-portal:covid19-3.1.0",
-    "tube": "quay.io/cdis/tube:2020.05",
+    "tube": "quay.io/cdis/tube:0.3.28",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2020.05",
     "hatchery": "quay.io/cdis/hatchery:2020.05",

--- a/qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2020.03",
+    "image": "quay.io/cdis/gen3fuse-sidecar:2020.05",
     "env": {
       "NAMESPACE": "default",
       "HOSTNAME": "qa-covid19.planx-pla.net"


### PR DESCRIPTION
This pull request updates the services to release 2020.05

Tube version is 2020.05 which included the commits for the tube fix

Also Sheepdog service is still on 4.0.1 as the sheepdog fix is not available yet