### PR TITLE
chore(jenkins): awshelper, ambassador to manifest

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -7,8 +7,10 @@
     "autodeploy": "no"
   },
   "versions": {
+    "ambassador": "quay.io/datawire/ambassador:0.82.0",
     "arborist": "quay.io/cdis/arborist:master",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
+    "awshelper": "quay.io/cdis/awshelper:master",
     "fence": "quay.io/cdis/fence:master",
     "indexd": "quay.io/cdis/indexd:master",
     "peregrine": "quay.io/cdis/peregrine:master",

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -7,8 +7,10 @@
     "autodeploy": "yes"
   },
   "versions": {
+    "ambassador": "quay.io/datawire/ambassador:0.82.0",
     "arborist": "quay.io/cdis/arborist:master",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
+    "awshelper": "quay.io/cdis/awshelper:master",
     "fence": "quay.io/cdis/fence:master",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "indexd": "quay.io/cdis/indexd:master",

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -7,9 +7,10 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "ambassador": "quay.io/datawire/ambassador:0.60.3",
+    "ambassador": "quay.io/datawire/ambassador:0.82.0",
     "arborist": "quay.io/cdis/arborist:master",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
+    "awshelper": "quay.io/cdis/awshelper:master",
     "fence": "quay.io/cdis/fence:master",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "indexd": "quay.io/cdis/indexd:master",

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -7,8 +7,10 @@
     "autodeploy": "yes"
   },
   "versions": {
+    "ambassador": "quay.io/datawire/ambassador:0.82.0",
     "arborist": "quay.io/cdis/arborist:master",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
+    "awshelper": "quay.io/cdis/awshelper:master",
     "fence": "quay.io/cdis/fence:master",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "indexd": "quay.io/cdis/indexd:master",

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -7,9 +7,10 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "ambassador": "quay.io/datawire/ambassador:0.60.3",
+    "ambassador": "quay.io/datawire/ambassador:0.82.0",
     "arborist": "quay.io/cdis/arborist:master",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
+    "awshelper": "quay.io/cdis/awshelper:master",
     "fence": "quay.io/cdis/fence:master",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "indexd": "quay.io/cdis/indexd:master",


### PR DESCRIPTION
* add awshelper to manifests for testing in cloud-automation PR's
* add new ambassador version to manifests for hatchery workspaces testing
