### PR TITLE
fix(mappings): jenkins-genomel rm vital_status add category data_file

### DIFF
--- a/jenkins-genomel.planx-pla.net/etlMapping.yaml
+++ b/jenkins-genomel.planx-pla.net/etlMapping.yaml
@@ -12,7 +12,6 @@ mappings:
           - name: gender
           - name: race
           - name: ethnicity
-          - name: vital_status
           - name: year_of_birth
     aggregated_props:
       - name: _samples_count
@@ -25,6 +24,7 @@ mappings:
     doc_type: file
     type: collector
     root: None
+    category: data_file
     props:
       - name: object_id
       - name: md5sum


### PR DESCRIPTION
Fixes errors in current ETL mapping for jenkins-genomel that are causing it to fail validation: 
1. vital_status is not defined in the dictionary, 
2. absence of data_file category causing "missing path declaration" errors for file props

