### PR TITLE
fix(mappings): jkns-niaid add comorbidities, add category data_file

### DIFF
--- a/jenkins-niaid.planx-pla.net/etlMapping.yaml
+++ b/jenkins-niaid.planx-pla.net/etlMapping.yaml
@@ -21,11 +21,14 @@ mappings:
       - path: hiv_history_records
         props:
           - name: arthxbase
-          - name: bshbvstat
-          - name: bshcvstat
           - name: cd4nadir
+          - name: fposdate
           - name: frstdthd
           - name: status
+      - path: comorbidities
+        props:
+          - name: bshbvstat
+          - name: bshcvstat
     aggregated_props:
       - name: _follow_ups_count
         path: follow_ups
@@ -64,6 +67,7 @@ mappings:
     doc_type: file
     type: collector
     root: None
+    category: data_file
     props:
       - name: object_id
       - name: md5sum


### PR DESCRIPTION
Fixes issues in jenkins-niaid that are causing it to fail ETL mapping validation.
bshbvstat and bshcvstat should be under comorbidities;
fposdate added as a prop under hiv_history_records to match with qa-niaid;
data_file category specified to resolve "missing path declaration" error for file props
