### PR TITLE
fix(mappings): qa-niaid rm drug_used

### DIFF
--- a/qa-niaid.planx-pla.net/etlMapping.yaml
+++ b/qa-niaid.planx-pla.net/etlMapping.yaml
@@ -158,7 +158,6 @@ mappings:
         props:
           - name: abc
           - name: abcv
-          - name: drug_used
           - name: thrpy
           - name: thrpyv
           - name: trz


### PR DESCRIPTION
qa-niaid ETL mapping failing validation: drug_used is not in dictionary. Remove