### PR TITLE
fix(mappings): qa-dcp.planx-pla.net rm age_at_enrollment

### DIFF
--- a/qa-dcp.planx-pla.net/etlMapping.yaml
+++ b/qa-dcp.planx-pla.net/etlMapping.yaml
@@ -84,10 +84,6 @@ mappings:
         path: demographics
         src: ethnicity
         fn: set
-      - name: age_at_enrollment
-        path: demographics
-        src: age_at_enrollment
-        fn: set
       - name: _samples_count
         path: samples
         fn: count


### PR DESCRIPTION
age_at_enrollment is not in the dictionary for qa-dcp (gtexdictionary 3.3.9)