### PR TITLE
PXP-5204 fix(mappings): enable ETL validation in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ script:
   - |
     for dir in *; do
       man=$dir/manifest.json; etl=$dir/etlMapping.yaml
-      [ -f $man ] && [ -f $etl ] && echo "ETL mapping validation for $dir" && gen3utils validate-etl-mapping $etl $man
+      if [ -f $man ] && [ -f $etl ]; then
+        echo "ETL mapping validation for $dir" && gen3utils validate-etl-mapping $etl $man
+      fi
     done

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
     for dir in *; do
       man=$dir/manifest.json; etl=$dir/etlMapping.yaml
       if [ -f $man ] && [ -f $etl ]; then
-        echo "ETL mapping validation for $dir" && gen3utils validate-etl-mapping $etl $man
+        echo "ETL mapping validation for $dir"
+        gen3utils validate-etl-mapping $etl $man || exit 1
       fi
     done

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,9 @@ script:
   # validate all the manifest.json files:
   - gen3utils validate-manifest */manifest.json
   
-    # validate ETL mapping files
-    # disabled for now because too many are failing validation...
-  # - |
-  #   for dir in *; do
-  #     man=$dir/manifest.json; etl=$dir/etlMapping.yaml
-  #     [ -f $man ] && [ -f $etl ] && echo "ETL mapping validation for $dir" && gen3utils validate-etl-mapping $etl $man
-  #   done
+  # validate ETL mapping files
+  - |
+    for dir in *; do
+      man=$dir/manifest.json; etl=$dir/etlMapping.yaml
+      [ -f $man ] && [ -f $etl ] && echo "ETL mapping validation for $dir" && gen3utils validate-etl-mapping $etl $man
+    done


### PR DESCRIPTION
- Now that the gitops-qa etl mappings are fixed, enable (uncomment) the validation in .travis.yml
- Use if-statement instead of && to check for manifest and ETL mapping; else if last item in loop happens to not have e.g. mapping, then loop exits with 1 even if all mappings that are present passed validation
- But do exit 1 on validation fail