### PR TITLE
chore(qa): Enable dashboard on qa-dcp

### DIFF
--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -26,7 +26,8 @@
     "wts": "quay.io/cdis/workspace-token-service:integration202007",
     "manifestservice": "quay.io/cdis/manifestservice:integration202007",
     "ssjdispatcher": "quay.io/cdis/ssjdispatcher:integration202007",
-    "metadata": "quay.io/cdis/metadata-service:integration202007"
+    "metadata": "quay.io/cdis/metadata-service:integration202007",
+    "dashboard": "quay.io/cdis/gen3-statics:master"
   },
   "google": {
     "enabled": "yes"


### PR DESCRIPTION
Required to mock some dbgap data / for testing purposes.