### PR TITLE
chore(qa): More fence replicas to improve stability of CI tests

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -321,7 +321,10 @@
       "strategy": "auto"
     },
     "fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
     },
     "presigned-url-fence": {
       "strategy": "auto",

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -318,7 +318,10 @@
       "strategy": "auto"
     },
     "fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
     },
     "presigned-url-fence": {
       "strategy": "auto",

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -302,12 +302,15 @@
       "strategy": "auto"
     },
     "fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
     },
     "presigned-url-fence": {
       "strategy": "auto",
-      "min": 3,
-      "max": 5,
+      "min": 2,
+      "max": 4,
       "targetCpu": 40
     },
     "indexd": {

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -322,7 +322,10 @@
       "strategy": "auto"
     },
     "fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
     },
     "presigned-url-fence": {
       "strategy": "auto",

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -319,7 +319,10 @@
       "strategy": "auto"
     },
     "fence": {
-      "strategy": "auto"
+      "strategy": "auto",
+      "min": 2,
+      "max": 4,
+      "targetCpu": 40
     },
     "presigned-url-fence": {
       "strategy": "auto",


### PR DESCRIPTION
RATIONALE:
While observing a failed test, we noticed the useryaml operation was executed around the following timestamp:
```
***** USERYAML LOGS *****
[2020-07-30 19:42:39,401][user_syncer][
```
So we looked for the nearest timestamp containing the operation:
`Removed Google Service Account`
This is what we found:
```
[5:58 PM] [2020-07-30 19:54:23,150][fence.blueprints.storage_creds.google][   INFO] Removed Google Service Account jniaid-dcf-integration-test-10@dcf-integration.iam.gserviceaccount.com Key with ID: abc123 from Google and our DB.
```
That indicates that, for this sampling, the delay in the reaction from the `useryaml` operation (to alter the access fo test users), operates in the timestamp between `[2020-07-30 19:54:23,150` and `[2020-07-30 19:42:39,401]`.

In this instances where the storage access is not revoked quickly, we have this example that took ~12 MINUTES.
Presuming we have nginx / uwsgi queueing up requests, the introduction of an additional replica should help us stabilize the flow of the CI tests.