### PR TITLE
chore(qa): Add missing ssjdispatcher property to qa-dcf

### DIFF
--- a/qa-dcf.planx-pla.net/manifest.json
+++ b/qa-dcf.planx-pla.net/manifest.json
@@ -197,6 +197,7 @@
     "logs_bucket": "logs-qaplanetv1-gen3",
     "sync_from_dbgap": "False",
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
+    "dispatcher_job_num": "10",
     "netpolicy": "on",
     "tier_access_level": "regular",
     "tier_access_limit": "50",


### PR DESCRIPTION
gen3 roll all is failing due to:
```  Warning  Failed     9m51s (x8 over 10m)  kubelet, ip-172-26-141-9.ec2.internal  Error: Couldn't find key dispatcher_job_num in ConfigMap qa-dcf/manifest-global```