### PR TITLE
turn network policies off for to test mariner in qa-covid19

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -39,7 +39,7 @@
     "logs_bucket": "logs-qaplanetv2-gen3",
     "sync_from_dbgap": "False",
     "dispatcher_job_num": "10",
-    "netpolicy": "on",
+    "netpolicy": "off",
     "public_datasets": true,
     "tier_access_level": "regular",
     "tier_access_limit": "2",


### PR DESCRIPTION
Matt wants to use Mariner to run the bayes model - in order to test Mariner in qa-covid19, network policies must be "off"