### PR TITLE
Update value mapping for community_area

### DIFF
--- a/qa-covid19.planx-pla.net/etlMapping.yaml
+++ b/qa-covid19.planx-pla.net/etlMapping.yaml
@@ -9,9 +9,9 @@ mappings:
       - name: country_region
       - name: community_area
         value_mappings:
-          - Greater Grand Crossing: 'Grand Crossing'
-          - South Lawndale (Little Village): 'Little Village'
-          - West Englewood: 'Englewood'
+          - GREATER GRAND CROSSING: 'Grand Crossing'
+          - SOUTH LAWNDALE (LITTLE VILLAGE): 'Little Village'
+          - WEST ENGLEWOOD: 'W.Englewood'
       - name: province_state
       - name: county
       - name: latitude


### PR DESCRIPTION
### Environment
qa-covid19

### Description
Update the value mappings for community_area as a way to truncate labels in the Neighborhood barchart.