### PR TITLE
chore/remove-labels

### DIFF
--- a/qa-covid19.planx-pla.net/portal/gitops.json
+++ b/qa-covid19.planx-pla.net/portal/gitops.json
@@ -950,8 +950,8 @@
           {
             "title": "Total Deaths per 10,000 in Chicago",
             "description": "The source of the data used to compile this chart is the Cook County Data Portal.",
-            "xTitle": "Neighborhood",
-            "yTitle": "Number of Deaths per 10,000",
+            "xTitle": "",
+            "yTitle": "",
             "type": "barChart",
             "layout": "vertical",
             "maxItems": 15,


### PR DESCRIPTION
### Environment
qa-covid19

### Description
Remove the x and y labels from the neighborhood barchart because the chart size is not responsive.