### PR TITLE
Update qa-niaid study viewer config

### DIFF
--- a/qa-niaid.planx-pla.net/etlMapping.yaml
+++ b/qa-niaid.planx-pla.net/etlMapping.yaml
@@ -1,6 +1,6 @@
 mappings:
   - name: qa-niaid_cmc
-    doc_type: cmc
+    doc_type: clinical_trials
     type: aggregator
     root: core_metadata_collection
     props:
@@ -17,6 +17,7 @@ mappings:
       - name: description
       - name: title
       - name: project_id
+      - name: submitter_id
   - name: qa-niaid_ct-file
     doc_type: ctfile
     type: aggregator

--- a/qa-niaid.planx-pla.net/etlMapping.yaml
+++ b/qa-niaid.planx-pla.net/etlMapping.yaml
@@ -17,7 +17,8 @@ mappings:
       - name: description
       - name: title
       - name: project_id
-      - name: submitter_id
+      - name: cmc_unique_id
+        src: submitter_id
   - name: qa-niaid_ct-file
     doc_type: ctfile
     type: aggregator
@@ -30,6 +31,8 @@ mappings:
       - name: data_format
       - name: data_type
       - name: project_id
+    parent_props:
+      - path: core_metadata_collections[cmc_unique_id:submitter_id]
   - name: qa-niaid_oa-file
     doc_type: oafile
     type: aggregator
@@ -42,3 +45,5 @@ mappings:
       - name: data_type
       - name: doc_url
       - name: project_id
+    parent_props:
+      - path: core_metadata_collections[cmc_unique_id:submitter_id]

--- a/qa-niaid.planx-pla.net/manifest.json
+++ b/qa-niaid.planx-pla.net/manifest.json
@@ -19,7 +19,7 @@
     "tube": "quay.io/cdis/tube:2020.08",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2020.08",
-    "requestor": "quay.io/cdis/requestor:feat_post-authz",
+    "requestor": "quay.io/cdis/requestor:feat_authz",
     "guppy": "quay.io/cdis/guppy:2020.08"
   },
   "arborist": {
@@ -48,7 +48,7 @@
   "guppy": {
     "indices": [{
         "index": "qa-niaid_cmc",
-        "type": "cmc"
+        "type": "clinical_trials"
       },
       {
         "index": "qa-niaid_ct-file",

--- a/qa-niaid.planx-pla.net/portal/gitops.json
+++ b/qa-niaid.planx-pla.net/portal/gitops.json
@@ -58,7 +58,7 @@
     "dataType": "clinical_trials",
     "title": "Studies",
     "titleField": "title",
-    "rowAccessor": "submitter_id",
+    "rowAccessor": "cmc_unique_id",
     "listItemConfig": {
       "blockFields": ["brief_summary"],
       "tableFields": ["condition", "responsible_party", "study_start_date", "study_completion_date", "study_design_primary_purpose", "publications"]

--- a/qa-niaid.planx-pla.net/portal/gitops.json
+++ b/qa-niaid.planx-pla.net/portal/gitops.json
@@ -28,7 +28,7 @@
     "navigation": {
       "items": [{
         "icon": "query",
-        "link": "/study-viewer/cmc",
+        "link": "/study-viewer/clinical_trials",
         "color": "#a2a2a2",
         "name": "Study Viewer"
       }]
@@ -55,10 +55,10 @@
   "studyViewerConfig": [{
     "openMode": "open-first",
     "openFirstRowAccessor": "",
-    "dataType": "cmc",
+    "dataType": "clinical_trials",
     "title": "Studies",
     "titleField": "title",
-    "rowAccessor": "project_id",
+    "rowAccessor": "submitter_id",
     "listItemConfig": {
       "blockFields": ["brief_summary"],
       "tableFields": ["condition", "responsible_party", "study_start_date", "study_completion_date", "study_design_primary_purpose", "publications"]


### PR DESCRIPTION
change ES index name so that we get a nicer study viewer URL
use `submitter_id` instead of `project_id` as unique ID. rename it `cmc_unique_id` and make it available in the 3 indices