### PR TITLE
fix: include ui-component button class in color overrides

### DIFF
--- a/qa-dcp.planx-pla.net/portal/gitops.css
+++ b/qa-dcp.planx-pla.net/portal/gitops.css
@@ -1,6 +1,7 @@
 :root {
   --primary-color: #c02f42;
   --secondary-color: #6d6e70;
+  --g3-primary-btn__bg-color: #c02f42;
 }
 
 /* Buttons */


### PR DESCRIPTION
This PR makes the default button color point to the primary color of bdcat.

Deployed in https://zakir.planx-pla.net