### PR TITLE
Updating QA env with integration202011 qa-dcp.planx-pla.net 1602513163

### DIFF
--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -7,27 +7,27 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.10",
+    "arborist": "quay.io/cdis/arborist:integration202011",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.10",
-    "indexd": "quay.io/cdis/indexd:2020.10",
-    "peregrine": "quay.io/cdis/peregrine:2020.10",
-    "pidgin": "quay.io/cdis/pidgin:2020.10",
-    "revproxy": "quay.io/cdis/nginx:2020.10",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.10",
-    "portal": "quay.io/cdis/data-portal:2020.10",
+    "fence": "quay.io/cdis/fence:integration202011",
+    "indexd": "quay.io/cdis/indexd:integration202011",
+    "peregrine": "quay.io/cdis/peregrine:integration202011",
+    "pidgin": "quay.io/cdis/pidgin:integration202011",
+    "revproxy": "quay.io/cdis/nginx:integration202011",
+    "sheepdog": "quay.io/cdis/sheepdog:integration202011",
+    "portal": "quay.io/cdis/data-portal:integration202011",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "quay.io/cdis/gen3-spark:2020.10",
-    "tube": "quay.io/cdis/tube:2020.10",
-    "guppy": "quay.io/cdis/guppy:2020.10",
-    "sower": "quay.io/cdis/sower:2020.10",
-    "hatchery": "quay.io/cdis/hatchery:2020.10",
+    "spark": "quay.io/cdis/gen3-spark:integration202011",
+    "tube": "quay.io/cdis/tube:integration202011",
+    "guppy": "quay.io/cdis/guppy:integration202011",
+    "sower": "quay.io/cdis/sower:integration202011",
+    "hatchery": "quay.io/cdis/hatchery:integration202011",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "wts": "quay.io/cdis/workspace-token-service:2020.10",
-    "manifestservice": "quay.io/cdis/manifestservice:2020.10",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.10",
-    "metadata": "quay.io/cdis/metadata-service:2020.10",
-    "dashboard": "quay.io/cdis/gen3-statics:2020.10"
+    "wts": "quay.io/cdis/workspace-token-service:integration202011",
+    "manifestservice": "quay.io/cdis/manifestservice:integration202011",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:integration202011",
+    "metadata": "quay.io/cdis/metadata-service:integration202011",
+    "dashboard": "quay.io/cdis/gen3-statics:integration202011"
   },
   "google": {
     "enabled": "yes"
@@ -43,7 +43,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/metadata-manifest-ingestion:2020.10",
+        "image": "quay.io/cdis/metadata-manifest-ingestion:integration202011",
         "pull_policy": "Always",
         "env": [
           {
@@ -83,7 +83,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/get-dbgap-metadata:2020.10",
+        "image": "quay.io/cdis/get-dbgap-metadata:integration202011",
         "pull_policy": "Always",
         "env": [],
         "volumeMounts": [
@@ -113,7 +113,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/manifest-indexing:2020.10",
+        "image": "quay.io/cdis/manifest-indexing:integration202011",
         "pull_policy": "Always",
         "env": [
           {
@@ -153,7 +153,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/download-indexd-manifest:2020.10",
+        "image": "quay.io/cdis/download-indexd-manifest:integration202011",
         "pull_policy": "Always",
         "env": [
           {
@@ -192,7 +192,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:2020.10",
+        "image": "quay.io/cdis/pelican-export:integration202011",
         "pull_policy": "Always",
         "env": [
           {
@@ -256,7 +256,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:2020.10",
+        "image": "quay.io/cdis/pelican-export:integration202011",
         "pull_policy": "Always",
         "env": [
           {
@@ -322,7 +322,7 @@
   ],
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2020.10"
+      "indexing": "quay.io/cdis/indexs3client:integration202011"
     }
   },
   "global": {

--- a/qa-dcp.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-dcp.planx-pla.net/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2020.10",
+    "image": "quay.io/cdis/gen3fuse-sidecar:integration202011",
     "env": {
       "NAMESPACE": "qa-dcp",
       "HOSTNAME": "qa-dcp.planx-pla.net"


### PR DESCRIPTION
Applying version integration202011 to qa-dcp.planx-pla.net

Remaining tests:

- [ ] test-apis-etlTest
- [ ] test-apis-userTokenTest
- [ ] test-google-googleServiceAccountRemovalTest
- [ ] test-google-googleServiceAccountTest
- [ ] sheepdogAndPeregrine-submitFileTest 