### PR TITLE
chore(bdcat): Update arborist to 2.5.0 in qa.planx-pla.net

### DIFF
--- a/qa.planx-pla.net/manifest.json
+++ b/qa.planx-pla.net/manifest.json
@@ -7,21 +7,21 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.03",
+    "arborist": "quay.io/cdis/arborist:2020.10",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.03",
+    "fence": "quay.io/cdis/fence:2020.10",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.10.2-debian-cloudwatch-1.0",
-    "indexd": "quay.io/cdis/indexd:2020.03",
-    "jenkins": "quay.io/cdis/jenkins:master",
+    "indexd": "quay.io/cdis/indexd:2020.10",
+    "jenkins": "quay.io/cdis/jenkins:2020.10",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
-    "peregrine": "quay.io/cdis/peregrine:2020.03",
-    "pidgin": "quay.io/cdis/pidgin:2020.03",
-    "portal": "quay.io/cdis/data-portal:2020.03",
-    "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.03",
-    "spark": "quay.io/cdis/gen3-spark:2020.03",
-    "tube": "quay.io/cdis/tube:2020.03",
-    "dashboard": "quay.io/cdis/gen3-statics:master"
+    "peregrine": "quay.io/cdis/peregrine:2020.10",
+    "pidgin": "quay.io/cdis/pidgin:2020.10",
+    "portal": "quay.io/cdis/data-portal:2020.10",
+    "revproxy": "quay.io/cdis/nginx:2020.10",
+    "sheepdog": "quay.io/cdis/sheepdog:2020.10",
+    "spark": "quay.io/cdis/gen3-spark:2020.10",
+    "tube": "quay.io/cdis/tube:2020.10",
+    "dashboard": "quay.io/cdis/gen3-statics:2020.10"
   },
   "arborist": {
     "deployment_version": "2"

--- a/qa.planx-pla.net/manifest.json
+++ b/qa.planx-pla.net/manifest.json
@@ -7,7 +7,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.10",
+    "arborist": "quay.io/cdis/arborist:2.5.0",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "fence": "quay.io/cdis/fence:2020.10",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.10.2-debian-cloudwatch-1.0",


### PR DESCRIPTION
Applying version 2020.10 to qa.planx-pla.net as per https://ctds-planx.atlassian.net/browse/PXP-7056