### PR TITLE
doc: Add plans-qa as CODEOWNERS for jenkins envs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,8 +4,8 @@ qa-canine.planx-pla.net/manifest.json @trevars @themarcelor @haraprasadj @atharv
 qa.planx-pla.net/manifest.json @themarcelor
 qaplanetv2.planx-pla.net
 
-qa-mickey.planx-pla.net/manifest.json @haraprasadj
-qa-brain.planx-pla.net/manifest.json @haraprasadj
+qa-mickey.planx-pla.net/manifest.json @haraprasadj @jingh8
+qa-brain.planx-pla.net/manifest.json @haraprasadj @jingh8
 
 qa-anvil.planx-pla.net/manifest.json @themarcelor
 qa-dcf.planx-pla.net/manifest.json @themarcelor
@@ -22,3 +22,9 @@ qa-microbiome.planx-pla.net/manifest.json @atharvar28
 qa-nde.planx-pla.net/manifest.json @atharvar28
 qa-niaid.planx-pla.net/manifest.json @atharvar28
 qa-tb.planx-pla.net/manifest.json @atharvar28
+
+jenkins-blood.planx-pla.net/manifest.json @themarcelor @haraprasadj @atharvar28 @jingh8
+jenkins-brain.planx-pla.net/manifest.json @themarcelor @haraprasadj @atharvar28 @jingh8
+jenkins-dcp.planx-pla.net/manifest.json @themarcelor @haraprasadj @atharvar28 @jingh8
+jenkins-genomel.planx-pla.net/manifest.json @themarcelor @haraprasadj @atharvar28 @jingh8
+jenkins-niaid.planx-pla.net/manifest.json @themarcelor @haraprasadj @atharvar28 @jingh8


### PR DESCRIPTION
add planx-qa as CODEOWNERS for jenkins envs
add  jingh8 to qa-mickey.planx-pla.net/manifest.json and qa-brain.planx-pla.net/manifest.json 