### PR TITLE
chore(multiple): remove deprecated tube section

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -276,9 +276,6 @@
       "case"
     ]
   },
-  "tube": {
-    "es_index_name": "blood"
-  },
   "global": {
     "environment": "qaplanetv1",
     "hostname": "jenkins-blood.planx-pla.net",

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -262,9 +262,6 @@
   "peregrine": {
     "sidecar": "True"
   },
-  "tube": {
-    "es_index_name": "etl"
-  },
   "jupyterhub": {
     "enabled": "yes",
     "containers": [

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -257,9 +257,6 @@
   "peregrine": {
     "sidecar": "False"
   },
-  "tube": {
-    "es_index_name": "qa-dcp"
-  },
   "global": {
     "environment": "qaplanetv1",
     "hostname": "jenkins-dcp.planx-pla.net",

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -277,9 +277,6 @@
   "peregrine": {
     "sidecar": "True"
   },
-  "tube": {
-    "es_index_name": "genomel_1"
-  },
   "global": {
     "environment": "qaplanetv1",
     "hostname": "jenkins-genomel.planx-pla.net",

--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -49,9 +49,6 @@
   "jupyterhub": {
     "enabled": "no"
   },
-  "tube": {
-    "es_index_name": "mickey"
-  },
   "global": {
     "environment": "qaplanetv1",
     "hostname": "qa-mickey.planx-pla.net",


### PR DESCRIPTION
### Environments
* `qa-mickey`
* `jenkins-blood`
* `jenkins-brain`
* `jenkins-dcp`
* `jenkins-genomel`

### Description of changes
* Remove deprecated section for `tube` from the manifest