### PR TITLE
chore: qa-niaid (nct) to 2020.11 version for testing

### DIFF
--- a/qa-niaid.planx-pla.net/manifest.json
+++ b/qa-niaid.planx-pla.net/manifest.json
@@ -7,21 +7,21 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2.5.0",
+    "arborist": "quay.io/cdis/arborist:2020.11",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "dashboard": "quay.io/cdis/gen3-statics:2020.08",
-    "fence": "quay.io/cdis/fence:2020.08",
-    "indexd": "quay.io/cdis/indexd:2020.08",
-    "peregrine": "quay.io/cdis/peregrine:2020.08",
-    "pidgin": "quay.io/cdis/pidgin:2020.08",
-    "revproxy": "quay.io/cdis/nginx:2020.08",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.08",
+    "dashboard": "quay.io/cdis/gen3-statics:2020.11",
+    "fence": "quay.io/cdis/fence:2020.11",
+    "indexd": "quay.io/cdis/indexd:2020.11",
+    "peregrine": "quay.io/cdis/peregrine:2020.11",
+    "pidgin": "quay.io/cdis/pidgin:2020.11",
+    "revproxy": "quay.io/cdis/nginx:2020.11",
+    "sheepdog": "quay.io/cdis/sheepdog:2020.11",
     "portal": "quay.io/cdis/data-portal:2.37.0",
-    "tube": "quay.io/cdis/tube:2020.08",
+    "tube": "quay.io/cdis/tube:2020.11",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "quay.io/cdis/gen3-spark:2020.08",
+    "spark": "quay.io/cdis/gen3-spark:2020.11",
     "requestor": "quay.io/cdis/requestor:1.2.0",
-    "guppy": "quay.io/cdis/guppy:2020.08"
+    "guppy": "quay.io/cdis/guppy:2020.11"
   },
   "arborist": {
     "deployment_version": "2"


### PR DESCRIPTION
Applying 2020.11 version to qa-nct for testing