### PR TITLE
chore(dictionary): update to dictionary release 3.7.2

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -33,7 +33,7 @@
     "environment": "qa-covid19",
     "hostname": "qa-covid19.planx-pla.net",
     "revproxy_arn": "arn:aws:acm:us-east-1:707767160287:certificate/c676c81c-9546-4e9a-9a72-725dd3912bc8",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/covid19-datadictionary/3.7.1/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/covid19-datadictionary/3.7.2/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-qaplanetv2-gen3",
     "logs_bucket": "logs-qaplanetv2-gen3",


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://occ-data.atlassian.net/browse/COV-534
### Environments
QA-covid

### Description of changes
Updated to dictionary release 3.7.2 to complete the data migration for CCMap & OWID2 projects.