### PR TITLE
chore(midrc): Enabling useProfileDropdown for jenkins-brain only

### DIFF
--- a/jenkins-brain.planx-pla.net/portal/gitops.json
+++ b/jenkins-brain.planx-pla.net/portal/gitops.json
@@ -110,6 +110,24 @@
         }
       ]
     },
+    "topBar": {
+      "items": [
+        {
+          "link": "https://www.braincommons.org/",
+          "name": "About"
+        },
+        {
+          "icon": "upload",
+          "link": "/submission",
+          "name": "Submit Data"
+        },
+        {
+          "link": "https://gen3.org/resources/user/",
+          "name": "Documentation"
+        }
+      ],
+      "useProfileDropdown": true
+    },
     "login": {
       "title": "Brain Commons",
       "subTitle": "search, compare, and download data",


### PR DESCRIPTION
This must be enabled in at least one CI environment for testing purposes.