### PR TITLE
chore(qa): Update access backend on qa-anvil

### DIFF
--- a/qa-anvil.planx-pla.net/manifest.json
+++ b/qa-anvil.planx-pla.net/manifest.json
@@ -7,7 +7,7 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "access-backend": "quay.io/cdis/access-backend:1.1",
+    "access-backend": "quay.io/cdis/access-backend:1.3",
     "ambassador": "quay.io/datawire/ambassador:0.60.3",
     "arborist": "quay.io/cdis/arborist:2020.10",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",


### PR DESCRIPTION
Need to test this version of access-backend prior to its BDCAT PROD deployment.