### PR TITLE
feat: change "Downloadable" tab to file type

### DIFF
--- a/qa-anvil.planx-pla.net/etlMapping.yaml
+++ b/qa-anvil.planx-pla.net/etlMapping.yaml
@@ -124,3 +124,39 @@ mappings:
             fn: set
           - name: project_id
             fn: set
+          - name: anvil_project_id
+            src: anvil_project_id
+            fn: set
+          - name: sex
+            src: sex
+            fn: set
+          - name: age_value
+            src: age_value
+            fn: set
+          - name: ancestry
+            src: ancestry
+            fn: set
+          - name: disease_description
+            src: disease_description
+            fn: set
+          - name: phenotype_present
+            src: phenotype_present
+            fn: set
+          - name: phenotype_absent
+            src: phenotype_absent
+            fn: set
+          - name: disease_id
+            src: disease_id
+            fn: set
+          - name: solve_state
+            src: solve_state
+            fn: set
+          - name: congenital_status
+            src: congenital_status
+            fn: set
+          - name: age_of_onset
+            src: age_of_onset
+            fn: set
+          - name: phenotype_group
+            src: phenotype_group
+            fn: set

--- a/qa-anvil.planx-pla.net/portal/gitops.json
+++ b/qa-anvil.planx-pla.net/portal/gitops.json
@@ -370,26 +370,6 @@
 						"age_of_onset",
 						"phenotype_group"
 					]
-				}, {
-					"title": "Sample",
-					"fields": [
-						"sample_provider",
-						"tissue_affected_status",
-						"tissue_type",
-						"sample_type",
-						"original_material_type"
-					]
-				}, {
-					"title": "Sequencing",
-					"fields": [
-						"library_prep_kit_method",
-						"exome_capture_platform",
-						"capture_region_bed_file",
-						"reference_genome_build",
-						"sequencing_assay",
-						"alignment_method",
-						"data_processing_pipeline"
-					]
 				}]
 			},
 			"table": {

--- a/qa-anvil.planx-pla.net/portal/gitops.json
+++ b/qa-anvil.planx-pla.net/portal/gitops.json
@@ -1,442 +1,445 @@
 {
-	"gaTrackingId": "UA-119127212-3",
-	"graphql": {
-		"boardCounts": [{
-				"graphql": "_subject_count",
-				"name": "Subject",
-				"plural": "Subjects"
-			},
-			{
-				"graphql": "_sample_count",
-				"name": "Sample",
-				"plural": "Samples"
-			}
-		],
-		"chartCounts": [{
-			"graphql": "_subject_count",
-			"name": "Subject"
-		}],
-		"projectDetails": "boardCounts"
-	},
-	"components": {
-		"appName": "NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-Space (AnVIL)",
-		"index": {
-			"introduction": {
-				"heading": "The AnVIL",
-				"text": "The AnVIL supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer. The data commons supports cross-project analyses by harmonizing data from different projects through the collaborative development of a data dictionary, providing an API for data queries and download, and providing a cloud-based analysis workspace with rich tools and resources.",
-				"link": "/submission"
-			},
-			"buttons": [{
-					"name": "Define Data Field",
-					"icon": "anvil-planning",
-					"body": "The AnVIL defines the data in a general way. Please study the dictionary before you start browsing.",
-					"link": "/DD",
-					"label": "Learn more",
-					"color": "#035C94"
-				},
-				{
-					"name": "Explore Data",
-					"icon": "anvil-explore",
-					"body": "The Exploration Page gives you insights and a clear overview under selected factors.",
-					"link": "/explorer",
-					"label": "Explore data",
-					"color": "#035C94"
-				},
-				{
-					"name": "Analyze Data",
-					"icon": "anvil-analyze",
-					"body": "Analyze your selected subjects using Jupyter Notebooks in our secure cloud environment",
-					"link": "#hostname#workspace/",
-					"label": "Run analysis",
-					"color": "#035C94"
-				}
-			],
-			"homepageChartNodes": [{
-					"node": "subject",
-					"name": "Subjects"
-				},
-				{
-					"node": "sample",
-					"name": "Samples"
-				}
-			]
-		},
-		"navigation": {
-			"title": "The AnVIL",
-			"items": [{
-					"icon": "dictionary",
-					"link": "/DD",
-					"color": "#035C94",
-					"name": "Dictionary"
-				},
-				{
-					"icon": "exploration",
-					"link": "/explorer",
-					"color": "#035C94",
-					"name": "Exploration"
-				},
-				{
-					"icon": "workspace",
-					"link": "#hostname#workspace/",
-					"color": "#035C94",
-					"name": "Workspace"
-				},
-				{
-					"icon": "profile",
-					"link": "/identity",
-					"color": "#035C94",
-					"name": "Profile"
-				}
-			]
-		},
-		"login": {
-			"title": "NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-Space (AnVIL)",
-			"subTitle": "Explore, Analyze, and Share Data",
-			"text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
-			"contact": "If you have any questions about access or the registration process, please contact ",
-			"email": "support@datacommons.io"
-		},
-		"categorical9Colors": ["#035C94", "#7EBAC0", "#AEEBF2", "#E0DD10", "#40476D", "#FFA630", "#AE8799", "#035C94", "#462255"],
-		"categorical2Colors": ["#035C94", "#7EBAC0"]
-	},
-	"featureFlags": {
-		"explorer": true
-	},
-	"explorerConfig": [{
-			"tabTitle": "Data",
-			"charts": {
-				"project_id": {
-					"chartType": "count",
-					"title": "Projects"
-				},
-				"node_id": {
-					"chartType": "count",
-					"title": "Subjects"
-				},
-				"sex": {
-					"chartType": "pie",
-					"title": "Sex"
-				},
-				"ancestry": {
-					"chartType": "bar",
-					"title": "Ancestry"
-				}
-			},
-			"filters": {
-				"tabs": [{
-					"title": "Projects",
-					"fields": [
-						"project_id",
-						"project_short_name",
-						"project_dbgap_accession_number",
-						"project_dbgap_consent_text",
-						"project_dbgap_phs",
-						"project_name"
-					]
-				}, {
-					"title": "Subject",
-					"fields": [
-						"anvil_project_id",
-						"sex",
-						"age_value",
-						"ancestry",
-						"disease_description",
-						"phenotype_present",
-						"phenotype_absent",
-						"disease_id",
-						"solve_state",
-						"congenital_status",
-						"age_of_onset",
-						"phenotype_group"
-					]
-				}, {
-					"title": "Sample",
-					"fields": [
-						"sample_provider",
-						"tissue_affected_status",
-						"tissue_type",
-						"sample_type",
-						"original_material_type"
-					]
-				}, {
-					"title": "Sequencing",
-					"fields": [
-						"library_prep_kit_method",
-						"exome_capture_platform",
-						"capture_region_bed_file",
-						"reference_genome_build",
-						"sequencing_assay",
-						"alignment_method",
-						"data_processing_pipeline"
-					]
-				}]
-			},
-			"table": {
-				"enabled": true,
-				"fields": [
-					"project_id",
-					"anvil_project_id",
-					"ancestry",
-					"sex",
-					"age_value",
-					"phenotype_group",
-					"_samples_count",
-					"_sequencings_count"
-				]
-			},
-			"buttons": [{
-					"enabled": true,
-					"type": "export",
-					"title": "Export All to Terra",
-					"rightIcon": "external-link"
-				},
-				{
-					"enabled": true,
-					"type": "export-to-pfb",
-					"title": "Export to PFB",
-					"leftIcon": "datafile",
-					"rightIcon": "download"
-				},
-				{
-					"enabled": true,
-					"type": "export-to-workspace",
-					"title": "Export to Workspace",
-					"leftIcon": "datafile",
-					"rightIcon": "download"
-				}
-			],
-			"guppyConfig": {
-				"dataType": "subject",
-				"nodeCountTitle": "Subjects",
-				"fieldMapping": [{
-						"field": "disease_id",
-						"name": "Disease ID"
-					},
-					{
-						"field": "age_of_onset",
-						"name": "Age of Onset"
-					},
-					{
-						"field": "project_dbgap_accession_number",
-						"name": "Project dbGaP Accession Number"
-					},
-					{
-						"field": "project_dbgap_consent_text",
-						"name": "Project dbGaP Consent Text"
-					},
-					{
-						"field": "project_dbgap_phs",
-						"name": "Project dbGaP Phs"
-					}
-				],
-				"manifestMapping": {
-					"resourceIndexType": "file",
-					"resourceIdField": "object_id",
-					"referenceIdFieldInResourceIndex": "_subject_id",
-					"referenceIdFieldInDataIndex": "_subject_id"
-				},
-				"accessibleFieldCheckList": ["project_id"],
-				"accessibleValidationField": "project_id"
-			},
-			"getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
-			"terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
-		},
-		{
-			"tabTitle": "File",
-			"charts": {
-				"data_type": {
-					"chartType": "stackedBar",
-					"title": "File Type"
-				},
-				"data_format": {
-					"chartType": "stackedBar",
-					"title": "File Format"
-				}
-			},
-			"filters": {
-				"tabs": [{
-					"title": "File",
-					"fields": [
-						"project_id",
-						"data_category",
-						"data_type",
-						"data_format",
-						"analyte_type",
-						"sequencing_assay"
-					]
-				}]
-			},
-			"table": {
-				"enabled": true,
-				"fields": [
-					"project_id",
-					"subject_submitter_id",
-					"file_name",
-					"data_format",
-					"data_type",
-					"data_category",
-					"file_size",
-					"submitter_id",
-					"object_id",
-					"md5sum"
-				]
-			},
-			"guppyConfig": {
-				"dataType": "file",
-				"fieldMapping": [{
-					"field": "object_id",
-					"name": "GUID"
-				}],
-				"nodeCountTitle": "Files",
-				"manifestMapping": {
-					"resourceIndexType": "subject",
-					"resourceIdField": "_subject_id",
-					"referenceIdFieldInResourceIndex": "object_id",
-					"referenceIdFieldInDataIndex": "object_id"
-				},
-				"accessibleFieldCheckList": ["project_id"],
-				"accessibleValidationField": "project_id",
-				"downloadAccessor": "object_id"
-			},
-			"buttons": [{
-					"enabled": true,
-					"type": "export-files-to-workspace",
-					"title": "Export to Workspace",
-					"leftIcon": "datafile",
-					"rightIcon": "download"
-				},
-				{
-					"enabled": true,
-					"type": "export-files-to-pfb",
-					"title": "Export All to PFB",
-					"rightIcon": "external-link",
-					"tooltipText": "You have not selected any subjects to export. Please use the checkboxes on the left to select specific cases you would like to export."
-				},
-				{
-					"enabled": true,
-					"type": "export-files",
-					"title": "Export All to Terra",
-					"rightIcon": "external-link",
-					"tooltipText": "You have not selected any subjects to export. Please use the checkboxes on the left to select specific cases you would like to export."
-				}
-			],
-			"enableLimitedFilePFBExport": {
-				"sourceNodeField": "source_node"
-			},
-			"terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data",
-			"dropdowns": {}
-		},
-		{
-			"tabTitle": "Downloadable",
-			"adminAppliedPreFilters": {
-				"project_id": {
-					"selectedValues": ["DEV-QA"]
-				}
-			},
-			"charts": {
-				"data_type": {
-					"chartType": "stackedBar",
-					"title": "File Type"
-				},
-				"data_format": {
-					"chartType": "stackedBar",
-					"title": "File Format"
-				}
-			},
-			"filters": {
-				"tabs": [{
-					"title": "File",
-					"fields": [
-						"project_id",
-						"data_category",
-						"data_type",
-						"data_format",
-						"analyte_type",
-						"sequencing_assay"
-					]
-				}, {
-					"title": "Subject",
-					"fields": [
-						"anvil_project_id",
-						"sex",
-						"age_value",
-						"ancestry",
-						"disease_description",
-						"phenotype_present",
-						"phenotype_absent",
-						"disease_id",
-						"solve_state",
-						"congenital_status",
-						"age_of_onset",
-						"phenotype_group"
-					]
-				}]
-			},
-			"table": {
-				"enabled": true,
-				"fields": [
-					"project_id",
-					"subject_submitter_id",
-					"file_name",
-					"data_format",
-					"data_type",
-					"data_category",
-					"file_size",
-					"submitter_id",
-					"object_id",
-					"md5sum"
-				]
-			},
-			"guppyConfig": {
-				"dataType": "file",
-				"fieldMapping": [{
-					"field": "object_id",
-					"name": "GUID"
-				}],
-				"nodeCountTitle": "Files",
-				"manifestMapping": {
-					"resourceIndexType": "subject",
-					"resourceIdField": "_subject_id",
-					"referenceIdFieldInResourceIndex": "object_id",
-					"referenceIdFieldInDataIndex": "object_id"
-				},
-				"accessibleFieldCheckList": ["project_id"],
-				"accessibleValidationField": "project_id",
-				"downloadAccessor": "object_id"
-			},
-			"buttons": [{
-					"enabled": true,
-					"type": "file-manifest",
-					"title": "Download Manifest",
-					"leftIcon": "datafile",
-					"rightIcon": "download",
-					"fileName": "file-manifest.json"
-				},
-				{
-					"enabled": true,
-					"type": "export-files-to-workspace",
-					"title": "Export to Workspace",
-					"leftIcon": "datafile"
-				},
-				{
-					"enabled": true,
-					"type": "export-files-to-pfb",
-					"title": "Export All to PFB",
-					"rightIcon": "external-link",
-					"tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
-				},
-				{
-					"enabled": true,
-					"type": "export-files",
-					"title": "Export All to Terra",
-					"rightIcon": "external-link",
-					"tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
-				}
-			],
-			"enableLimitedFilePFBExport": {
-				"sourceNodeField": "source_node"
-			},
-			"terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
-		}
-	]
+  "gaTrackingId": "UA-119127212-3",
+  "graphql": {
+    "boardCounts": [
+      {
+        "graphql": "_subject_count",
+        "name": "Subject",
+        "plural": "Subjects"
+      },
+      {
+        "graphql": "_sample_count",
+        "name": "Sample",
+        "plural": "Samples"
+      }
+    ],
+    "chartCounts": [
+      {
+        "graphql": "_subject_count",
+        "name": "Subject"
+      }
+    ],
+    "projectDetails": "boardCounts"
+  },
+  "components": {
+    "appName": "NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-Space (AnVIL)",
+    "index": {
+      "introduction": {
+        "heading": "The AnVIL",
+        "text": "The AnVIL supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer. The data commons supports cross-project analyses by harmonizing data from different projects through the collaborative development of a data dictionary, providing an API for data queries and download, and providing a cloud-based analysis workspace with rich tools and resources.",
+        "link": "/submission"
+      },
+      "buttons": [
+        {
+          "name": "Define Data Field",
+          "icon": "anvil-planning",
+          "body": "The AnVIL defines the data in a general way. Please study the dictionary before you start browsing.",
+          "link": "/DD",
+          "label": "Learn more",
+          "color": "#035C94"
+        },
+        {
+          "name": "Explore Data",
+          "icon": "anvil-explore",
+          "body": "The Exploration Page gives you insights and a clear overview under selected factors.",
+          "link": "/explorer",
+          "label": "Explore data",
+          "color": "#035C94"
+        },
+        {
+          "name": "Analyze Data",
+          "icon": "anvil-analyze",
+          "body": "Analyze your selected subjects using Jupyter Notebooks in our secure cloud environment",
+          "link": "#hostname#workspace/",
+          "label": "Run analysis",
+          "color": "#035C94"
+        }
+      ],
+      "homepageChartNodes": [
+        {
+          "node": "subject",
+          "name": "Subjects"
+        },
+        {
+          "node": "sample",
+          "name": "Samples"
+        }
+      ]
+    },
+    "navigation": {
+      "title": "The AnVIL",
+      "items": [
+        {
+          "icon": "dictionary",
+          "link": "/DD",
+          "color": "#035C94",
+          "name": "Dictionary"
+        },
+        {
+          "icon": "exploration",
+          "link": "/explorer",
+          "color": "#035C94",
+          "name": "Exploration"
+        },
+        {
+          "icon": "workspace",
+          "link": "#hostname#workspace/",
+          "color": "#035C94",
+          "name": "Workspace"
+        },
+        {
+          "icon": "profile",
+          "link": "/identity",
+          "color": "#035C94",
+          "name": "Profile"
+        }
+      ]
+    },
+    "login": {
+      "title": "NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-Space (AnVIL)",
+      "subTitle": "Explore, Analyze, and Share Data",
+      "text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
+      "contact": "If you have any questions about access or the registration process, please contact ",
+      "email": "support@datacommons.io"
+    },
+    "categorical9Colors": ["#035C94", "#7EBAC0", "#AEEBF2", "#E0DD10", "#40476D", "#FFA630", "#AE8799", "#035C94", "#462255"],
+    "categorical2Colors": ["#035C94", "#7EBAC0"]
+  },
+  "featureFlags": {
+    "explorer": true
+  },
+  "explorerConfig":[
+    {
+      "tabTitle": "Data",
+      "charts": {
+        "project_id": {
+          "chartType": "count",
+          "title": "Projects"
+        },
+        "node_id": {
+          "chartType": "count",
+          "title": "Subjects"
+        },
+        "sex": {
+          "chartType": "pie",
+          "title": "Sex"
+        },
+        "ancestry": {
+          "chartType": "bar",
+          "title": "Ancestry"
+        }
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "Projects",
+            "fields": [
+              "project_id",
+              "project_short_name",
+              "project_dbgap_accession_number",
+              "project_dbgap_consent_text",
+              "project_dbgap_phs",
+              "project_name"
+            ]
+          }, {
+            "title": "Subject",
+            "fields":[
+              "anvil_project_id",
+              "sex",
+              "age_value",
+              "ancestry",
+              "disease_description", 
+              "phenotype_present", 
+              "phenotype_absent", 
+              "disease_id", 
+              "solve_state", 
+              "congenital_status", 
+              "age_of_onset",
+              "phenotype_group"
+            ]
+          }, {
+            "title": "Sample",
+            "fields": [
+              "sample_provider",
+              "tissue_affected_status",
+              "tissue_type",
+              "sample_type",
+              "original_material_type"
+            ]
+          }, {
+            "title": "Sequencing",
+            "fields": [
+              "library_prep_kit_method", 
+              "exome_capture_platform", 
+              "capture_region_bed_file", 
+              "reference_genome_build", 
+              "sequencing_assay", 
+              "alignment_method", 
+              "data_processing_pipeline"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "anvil_project_id",
+          "ancestry",
+          "sex",
+          "age_value",
+          "phenotype_group",
+          "_samples_count",
+          "_sequencings_count"
+        ]
+      },
+      "buttons": [
+        {
+          "enabled": true,
+          "type": "export",
+          "title": "Export All to Terra",
+          "rightIcon": "external-link"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-pfb",
+          "title": "Export to PFB",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "subject",
+        "nodeCountTitle": "Subjects",
+        "fieldMapping": [
+          { "field": "disease_id", "name": "Disease ID" }, 
+          { "field": "age_of_onset", "name": "Age of Onset" },
+          { "field": "project_dbgap_accession_number", "name": "Project dbGaP Accession Number" },
+          { "field": "project_dbgap_consent_text", "name":"Project dbGaP Consent Text"},
+          { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}    
+        ],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "_subject_id",
+          "referenceIdFieldInDataIndex": "_subject_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      },
+      "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
+      "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
+    },
+    {
+      "tabTitle": "File",
+      "charts": {
+        "data_type": {
+          "chartType": "stackedBar",
+          "title": "File Type"
+        },
+        "data_format": {
+          "chartType": "stackedBar",
+          "title": "File Format"
+        }
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "File",
+            "fields": [
+              "project_id",
+              "data_category",
+              "data_type",
+              "data_format",
+              "analyte_type", 
+              "sequencing_assay"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "subject_submitter_id",
+          "file_name",
+          "data_format",
+          "data_type",
+          "data_category",
+          "file_size",
+          "submitter_id",
+          "object_id",
+          "md5sum"
+        ]
+      },
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          { "field": "object_id", "name": "GUID" }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "subject",
+          "resourceIdField": "_subject_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
+      "buttons": [
+        {
+          "enabled": true,
+          "type": "export-files-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        },
+        {
+          "enabled": true,
+          "type": "export-files-to-pfb",
+          "title": "Export All to PFB",
+          "rightIcon": "external-link",
+          "tooltipText": "You have not selected any subjects to export. Please use the checkboxes on the left to select specific cases you would like to export."
+        },
+        {
+          "enabled": true,
+          "type": "export-files",
+          "title": "Export All to Terra",
+          "rightIcon": "external-link",
+          "tooltipText": "You have not selected any subjects to export. Please use the checkboxes on the left to select specific cases you would like to export."
+        }
+      ],
+      "enableLimitedFilePFBExport": {
+        "sourceNodeField": "source_node"
+      },
+      "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data",
+      "dropdowns": {}
+    },
+    {
+      "tabTitle": "Downloadable",
+      "adminAppliedPreFilters": {
+        "project_id": {
+          "selectedValues": ["DEV-QA"]
+        }
+      },
+      "charts": {
+        "data_type": {
+          "chartType": "stackedBar",
+          "title": "File Type"
+        },
+        "data_format": {
+          "chartType": "stackedBar",
+          "title": "File Format"
+        }
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "File",
+            "fields": [
+              "project_id",
+              "data_category",
+              "data_type",
+              "data_format",
+              "analyte_type",
+              "sequencing_assay"
+            ]
+          }, {
+            "title": "Subject",
+            "fields": [
+              "anvil_project_id",
+              "sex",
+              "age_value",
+              "ancestry",
+              "disease_description",
+              "phenotype_present",
+              "phenotype_absent",
+              "disease_id",
+              "solve_state",
+              "congenital_status",
+              "age_of_onset",
+              "phenotype_group"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "subject_submitter_id",
+          "file_name",
+          "data_format",
+          "data_type",
+          "data_category",
+          "file_size",
+          "submitter_id",
+          "object_id",
+          "md5sum"
+        ]
+      },
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          {
+          "field": "object_id",
+          "name": "GUID"
+          }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "subject",
+          "resourceIdField": "_subject_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
+      "buttons": [
+      {
+          "enabled": true,
+          "type": "file-manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "file-manifest.json"
+        },
+        {
+          "enabled": true,
+          "type": "export-files-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile"
+        },
+        {
+          "enabled": true,
+          "type": "export-files-to-pfb",
+          "title": "Export All to PFB",
+          "rightIcon": "external-link",
+          "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
+        },
+        {
+          "enabled": true,
+          "type": "export-files",
+          "title": "Export All to Terra",
+          "rightIcon": "external-link",
+          "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
+        }
+      ],
+      "enableLimitedFilePFBExport": {
+        "sourceNodeField": "source_node"
+      },
+      "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
+    }
+  ]
 }

--- a/qa-anvil.planx-pla.net/portal/gitops.json
+++ b/qa-anvil.planx-pla.net/portal/gitops.json
@@ -371,25 +371,6 @@
           "md5sum"
         ]
       },
-      "guppyConfig": {
-        "dataType": "file",
-        "fieldMapping": [
-          {
-          "field": "object_id",
-          "name": "GUID"
-          }
-        ],
-        "nodeCountTitle": "Files",
-        "manifestMapping": {
-          "resourceIndexType": "subject",
-          "resourceIdField": "_subject_id",
-          "referenceIdFieldInResourceIndex": "object_id",
-          "referenceIdFieldInDataIndex": "object_id"
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id",
-        "downloadAccessor": "object_id"
-      },
       "buttons": [
       {
           "enabled": true,

--- a/qa-anvil.planx-pla.net/portal/gitops.json
+++ b/qa-anvil.planx-pla.net/portal/gitops.json
@@ -332,73 +332,26 @@
         }
       },
       "charts": {
-        "project_id": {
-          "chartType": "count",
-          "title": "Projects"
+        "data_type": {
+          "chartType": "stackedBar",
+          "title": "File Type"
         },
-        "node_id": {
-          "chartType": "count",
-          "title": "Subjects"
-        },
-        "sex": {
-          "chartType": "pie",
-          "title": "Sex"
-        },
-        "ancestry": {
-          "chartType": "bar",
-          "title": "Ancestry"
+        "data_format": {
+          "chartType": "stackedBar",
+          "title": "File Format"
         }
       },
       "filters": {
         "tabs": [
           {
-            "title": "Projects",
+            "title": "File",
             "fields": [
               "project_id",
-              "project_short_name",
-              "project_dbgap_accession_number",
-              "project_dbgap_consent_text",
-              "project_dbgap_phs",
-              "project_name",
+              "data_category",
               "data_type",
               "data_format",
-              "data_category"
-            ]
-          }, {
-            "title": "Subject",
-            "fields":[
-              "anvil_project_id",
-              "sex",
-              "age_value",
-              "ancestry",
-              "disease_description", 
-              "phenotype_present", 
-              "phenotype_absent", 
-              "disease_id", 
-              "solve_state", 
-              "congenital_status", 
-              "age_of_onset",
-              "phenotype_group"
-            ]
-          }, {
-            "title": "Sample",
-            "fields": [
-              "sample_provider",
-              "tissue_affected_status",
-              "tissue_type",
-              "sample_type",
-              "original_material_type"
-            ]
-          }, {
-            "title": "Sequencing",
-            "fields": [
-              "library_prep_kit_method", 
-              "exome_capture_platform", 
-              "capture_region_bed_file", 
-              "reference_genome_build", 
-              "sequencing_assay", 
-              "alignment_method", 
-              "data_processing_pipeline"
+              "analyte_type", 
+              "sequencing_assay"
             ]
           }
         ]
@@ -407,81 +360,74 @@
         "enabled": true,
         "fields": [
           "project_id",
-          "anvil_project_id",
-          "ancestry",
-          "sex",
-          "age_value",
-          "phenotype_group",
-          "_samples_count",
-          "_sequencings_count"
+          "subject_submitter_id",
+          "file_name",
+          "data_format",
+          "data_type",
+          "data_category",
+          "file_size",
+          "submitter_id",
+          "object_id",
+          "md5sum"
         ]
       },
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          { "field": "object_id", "name": "GUID" }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "subject",
+          "resourceIdField": "_subject_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
       "dropdowns": {
-        "download": {
-          "title": "Download"
+        "export": {
+          "title": "Export"
         }
       },
       "buttons": [
         {
           "enabled": true,
-          "type": "data",
-          "title": "Download Clinical",
-          "leftIcon": "user",
-          "rightIcon": "download",
-          "fileName": "clinical.json",
-          "dropdownId": "download",
-          "tooltipText": "You have not selected any subjects to download. Please use the checkboxes on the left to select specific subjects you would like to download."
-        },
-        {
-          "enabled": true,
-          "type": "manifest",
+          "type": "file-manifest",
           "title": "Download Manifest",
           "leftIcon": "datafile",
           "rightIcon": "download",
-          "fileName": "manifest.json",
-          "dropdownId": "download"
+          "fileName": "file-manifest.json"
         },
         {
           "enabled": true,
-          "type": "export",
-          "title": "Export All to Terra",
-          "rightIcon": "external-link"
-        },
-        {
-          "enabled": true,
-          "type": "export-to-pfb",
-          "title": "Export to PFB",
-          "leftIcon": "datafile",
-          "rightIcon": "download"
-        },
-        {
-          "enabled": true,
-          "type": "export-to-workspace",
+          "type": "export-files-to-workspace",
           "title": "Export to Workspace",
           "leftIcon": "datafile",
-          "rightIcon": "download"
+          "dropdownId": "export"
+        },
+        {
+          "enabled": true,
+          "type": "export-files-to-pfb",
+          "title": "Export All to PFB",
+          "rightIcon": "external-link",
+          "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export.",
+          "dropdownId": "export"
+        },
+        {
+          "enabled": true,
+          "type": "export-files",
+          "title": "Export All to Terra",
+          "rightIcon": "external-link",
+          "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export.",
+          "dropdownId": "export"
         }
       ],
-      "guppyConfig": {
-        "dataType": "subject",
-        "nodeCountTitle": "Subjects",
-        "fieldMapping": [
-          { "field": "disease_id", "name": "Disease ID" }, 
-          { "field": "age_of_onset", "name": "Age of Onset" },
-          { "field": "project_dbgap_accession_number", "name": "Project dbGaP Accession Number" },
-          { "field": "project_dbgap_consent_text", "name":"Project dbGaP Consent Text"},
-          { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}    
-        ],
-        "manifestMapping": {
-          "resourceIndexType": "file",
-          "resourceIdField": "object_id",
-          "referenceIdFieldInResourceIndex": "_subject_id",
-          "referenceIdFieldInDataIndex": "_subject_id"
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id"
+      "enableLimitedFilePFBExport": {
+        "sourceNodeField": "source_node"
       },
-      "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
       "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
     }
   ]

--- a/qa-anvil.planx-pla.net/portal/gitops.json
+++ b/qa-anvil.planx-pla.net/portal/gitops.json
@@ -279,6 +279,22 @@
           "md5sum"
         ]
       },
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          { "field": "object_id", "name": "GUID" }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "subject",
+          "resourceIdField": "_subject_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
       "buttons": [
         {
           "enabled": true,

--- a/qa-anvil.planx-pla.net/portal/gitops.json
+++ b/qa-anvil.planx-pla.net/portal/gitops.json
@@ -279,22 +279,6 @@
           "md5sum"
         ]
       },
-      "guppyConfig": {
-        "dataType": "file",
-        "fieldMapping": [
-          { "field": "object_id", "name": "GUID" }
-        ],
-        "nodeCountTitle": "Files",
-        "manifestMapping": {
-          "resourceIndexType": "subject",
-          "resourceIdField": "_subject_id",
-          "referenceIdFieldInResourceIndex": "object_id",
-          "referenceIdFieldInDataIndex": "object_id"
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id",
-        "downloadAccessor": "object_id"
-      },
       "buttons": [
         {
           "enabled": true,
@@ -436,6 +420,22 @@
           "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
         }
       ],
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          { "field": "object_id", "name": "GUID" }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "subject",
+          "resourceIdField": "_subject_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
       "enableLimitedFilePFBExport": {
         "sourceNodeField": "source_node"
       },

--- a/qa-anvil.planx-pla.net/portal/gitops.json
+++ b/qa-anvil.planx-pla.net/portal/gitops.json
@@ -1,434 +1,462 @@
 {
-  "gaTrackingId": "UA-119127212-3",
-  "graphql": {
-    "boardCounts": [
-      {
-        "graphql": "_subject_count",
-        "name": "Subject",
-        "plural": "Subjects"
-      },
-      {
-        "graphql": "_sample_count",
-        "name": "Sample",
-        "plural": "Samples"
-      }
-    ],
-    "chartCounts": [
-      {
-        "graphql": "_subject_count",
-        "name": "Subject"
-      }
-    ],
-    "projectDetails": "boardCounts"
-  },
-  "components": {
-    "appName": "NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-Space (AnVIL)",
-    "index": {
-      "introduction": {
-        "heading": "The AnVIL",
-        "text": "The AnVIL supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer. The data commons supports cross-project analyses by harmonizing data from different projects through the collaborative development of a data dictionary, providing an API for data queries and download, and providing a cloud-based analysis workspace with rich tools and resources.",
-        "link": "/submission"
-      },
-      "buttons": [
-        {
-          "name": "Define Data Field",
-          "icon": "anvil-planning",
-          "body": "The AnVIL defines the data in a general way. Please study the dictionary before you start browsing.",
-          "link": "/DD",
-          "label": "Learn more",
-          "color": "#035C94"
-        },
-        {
-          "name": "Explore Data",
-          "icon": "anvil-explore",
-          "body": "The Exploration Page gives you insights and a clear overview under selected factors.",
-          "link": "/explorer",
-          "label": "Explore data",
-          "color": "#035C94"
-        },
-        {
-          "name": "Analyze Data",
-          "icon": "anvil-analyze",
-          "body": "Analyze your selected subjects using Jupyter Notebooks in our secure cloud environment",
-          "link": "#hostname#workspace/",
-          "label": "Run analysis",
-          "color": "#035C94"
-        }
-      ],
-      "homepageChartNodes": [
-        {
-          "node": "subject",
-          "name": "Subjects"
-        },
-        {
-          "node": "sample",
-          "name": "Samples"
-        }
-      ]
-    },
-    "navigation": {
-      "title": "The AnVIL",
-      "items": [
-        {
-          "icon": "dictionary",
-          "link": "/DD",
-          "color": "#035C94",
-          "name": "Dictionary"
-        },
-        {
-          "icon": "exploration",
-          "link": "/explorer",
-          "color": "#035C94",
-          "name": "Exploration"
-        },
-        {
-          "icon": "workspace",
-          "link": "#hostname#workspace/",
-          "color": "#035C94",
-          "name": "Workspace"
-        },
-        {
-          "icon": "profile",
-          "link": "/identity",
-          "color": "#035C94",
-          "name": "Profile"
-        }
-      ]
-    },
-    "login": {
-      "title": "NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-Space (AnVIL)",
-      "subTitle": "Explore, Analyze, and Share Data",
-      "text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
-      "contact": "If you have any questions about access or the registration process, please contact ",
-      "email": "support@datacommons.io"
-    },
-    "categorical9Colors": ["#035C94", "#7EBAC0", "#AEEBF2", "#E0DD10", "#40476D", "#FFA630", "#AE8799", "#035C94", "#462255"],
-    "categorical2Colors": ["#035C94", "#7EBAC0"]
-  },
-  "featureFlags": {
-    "explorer": true
-  },
-  "explorerConfig":[
-    {
-      "tabTitle": "Data",
-      "charts": {
-        "project_id": {
-          "chartType": "count",
-          "title": "Projects"
-        },
-        "node_id": {
-          "chartType": "count",
-          "title": "Subjects"
-        },
-        "sex": {
-          "chartType": "pie",
-          "title": "Sex"
-        },
-        "ancestry": {
-          "chartType": "bar",
-          "title": "Ancestry"
-        }
-      },
-      "filters": {
-        "tabs": [
-          {
-            "title": "Projects",
-            "fields": [
-              "project_id",
-              "project_short_name",
-              "project_dbgap_accession_number",
-              "project_dbgap_consent_text",
-              "project_dbgap_phs",
-              "project_name"
-            ]
-          }, {
-            "title": "Subject",
-            "fields":[
-              "anvil_project_id",
-              "sex",
-              "age_value",
-              "ancestry",
-              "disease_description", 
-              "phenotype_present", 
-              "phenotype_absent", 
-              "disease_id", 
-              "solve_state", 
-              "congenital_status", 
-              "age_of_onset",
-              "phenotype_group"
-            ]
-          }, {
-            "title": "Sample",
-            "fields": [
-              "sample_provider",
-              "tissue_affected_status",
-              "tissue_type",
-              "sample_type",
-              "original_material_type"
-            ]
-          }, {
-            "title": "Sequencing",
-            "fields": [
-              "library_prep_kit_method", 
-              "exome_capture_platform", 
-              "capture_region_bed_file", 
-              "reference_genome_build", 
-              "sequencing_assay", 
-              "alignment_method", 
-              "data_processing_pipeline"
-            ]
-          }
-        ]
-      },
-      "table": {
-        "enabled": true,
-        "fields": [
-          "project_id",
-          "anvil_project_id",
-          "ancestry",
-          "sex",
-          "age_value",
-          "phenotype_group",
-          "_samples_count",
-          "_sequencings_count"
-        ]
-      },
-      "buttons": [
-        {
-          "enabled": true,
-          "type": "export",
-          "title": "Export All to Terra",
-          "rightIcon": "external-link"
-        },
-        {
-          "enabled": true,
-          "type": "export-to-pfb",
-          "title": "Export to PFB",
-          "leftIcon": "datafile",
-          "rightIcon": "download"
-        },
-        {
-          "enabled": true,
-          "type": "export-to-workspace",
-          "title": "Export to Workspace",
-          "leftIcon": "datafile",
-          "rightIcon": "download"
-        }
-      ],
-      "guppyConfig": {
-        "dataType": "subject",
-        "nodeCountTitle": "Subjects",
-        "fieldMapping": [
-          { "field": "disease_id", "name": "Disease ID" }, 
-          { "field": "age_of_onset", "name": "Age of Onset" },
-          { "field": "project_dbgap_accession_number", "name": "Project dbGaP Accession Number" },
-          { "field": "project_dbgap_consent_text", "name":"Project dbGaP Consent Text"},
-          { "field": "project_dbgap_phs", "name":"Project dbGaP Phs"}    
-        ],
-        "manifestMapping": {
-          "resourceIndexType": "file",
-          "resourceIdField": "object_id",
-          "referenceIdFieldInResourceIndex": "_subject_id",
-          "referenceIdFieldInDataIndex": "_subject_id"
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id"
-      },
-      "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
-      "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
-    },
-    {
-      "tabTitle": "File",
-      "charts": {
-        "data_type": {
-          "chartType": "stackedBar",
-          "title": "File Type"
-        },
-        "data_format": {
-          "chartType": "stackedBar",
-          "title": "File Format"
-        }
-      },
-      "filters": {
-        "tabs": [
-          {
-            "title": "File",
-            "fields": [
-              "project_id",
-              "data_category",
-              "data_type",
-              "data_format",
-              "analyte_type", 
-              "sequencing_assay"
-            ]
-          }
-        ]
-      },
-      "table": {
-        "enabled": true,
-        "fields": [
-          "project_id",
-          "subject_submitter_id",
-          "file_name",
-          "data_format",
-          "data_type",
-          "data_category",
-          "file_size",
-          "submitter_id",
-          "object_id",
-          "md5sum"
-        ]
-      },
-      "guppyConfig": {
-        "dataType": "file",
-        "fieldMapping": [
-          { "field": "object_id", "name": "GUID" }
-        ],
-        "nodeCountTitle": "Files",
-        "manifestMapping": {
-          "resourceIndexType": "subject",
-          "resourceIdField": "_subject_id",
-          "referenceIdFieldInResourceIndex": "object_id",
-          "referenceIdFieldInDataIndex": "object_id"
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id",
-        "downloadAccessor": "object_id"
-      },
-      "buttons": [
-        {
-          "enabled": true,
-          "type": "export-files-to-workspace",
-          "title": "Export to Workspace",
-          "leftIcon": "datafile",
-          "rightIcon": "download"
-        },
-        {
-          "enabled": true,
-          "type": "export-files-to-pfb",
-          "title": "Export All to PFB",
-          "rightIcon": "external-link",
-          "tooltipText": "You have not selected any subjects to export. Please use the checkboxes on the left to select specific cases you would like to export."
-        },
-        {
-          "enabled": true,
-          "type": "export-files",
-          "title": "Export All to Terra",
-          "rightIcon": "external-link",
-          "tooltipText": "You have not selected any subjects to export. Please use the checkboxes on the left to select specific cases you would like to export."
-        }
-      ],
-      "enableLimitedFilePFBExport": {
-        "sourceNodeField": "source_node"
-      },
-      "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data",
-      "dropdowns": {}
-    },
-    {
-      "tabTitle": "Downloadable",
-      "adminAppliedPreFilters": {
-        "project_id": { 
-          "selectedValues": ["DEV-QA"]
-        }
-      },
-      "charts": {
-        "data_type": {
-          "chartType": "stackedBar",
-          "title": "File Type"
-        },
-        "data_format": {
-          "chartType": "stackedBar",
-          "title": "File Format"
-        }
-      },
-      "filters": {
-        "tabs": [
-          {
-            "title": "File",
-            "fields": [
-              "project_id",
-              "data_category",
-              "data_type",
-              "data_format",
-              "analyte_type", 
-              "sequencing_assay"
-            ]
-          }
-        ]
-      },
-      "table": {
-        "enabled": true,
-        "fields": [
-          "project_id",
-          "subject_submitter_id",
-          "file_name",
-          "data_format",
-          "data_type",
-          "data_category",
-          "file_size",
-          "submitter_id",
-          "object_id",
-          "md5sum"
-        ]
-      },
-      "guppyConfig": {
-        "dataType": "file",
-        "fieldMapping": [
-          { "field": "object_id", "name": "GUID" }
-        ],
-        "nodeCountTitle": "Files",
-        "manifestMapping": {
-          "resourceIndexType": "subject",
-          "resourceIdField": "_subject_id",
-          "referenceIdFieldInResourceIndex": "object_id",
-          "referenceIdFieldInDataIndex": "object_id"
-        },
-        "accessibleFieldCheckList": ["project_id"],
-        "accessibleValidationField": "project_id",
-        "downloadAccessor": "object_id"
-      },
-      "dropdowns": {
-        "export": {
-          "title": "Export"
-        }
-      },
-      "buttons": [
-        {
-          "enabled": true,
-          "type": "file-manifest",
-          "title": "Download Manifest",
-          "leftIcon": "datafile",
-          "rightIcon": "download",
-          "fileName": "file-manifest.json"
-        },
-        {
-          "enabled": true,
-          "type": "export-files-to-workspace",
-          "title": "Export to Workspace",
-          "leftIcon": "datafile",
-          "dropdownId": "export"
-        },
-        {
-          "enabled": true,
-          "type": "export-files-to-pfb",
-          "title": "Export All to PFB",
-          "rightIcon": "external-link",
-          "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export.",
-          "dropdownId": "export"
-        },
-        {
-          "enabled": true,
-          "type": "export-files",
-          "title": "Export All to Terra",
-          "rightIcon": "external-link",
-          "tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export.",
-          "dropdownId": "export"
-        }
-      ],
-      "enableLimitedFilePFBExport": {
-        "sourceNodeField": "source_node"
-      },
-      "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
-    }
-  ]
+	"gaTrackingId": "UA-119127212-3",
+	"graphql": {
+		"boardCounts": [{
+				"graphql": "_subject_count",
+				"name": "Subject",
+				"plural": "Subjects"
+			},
+			{
+				"graphql": "_sample_count",
+				"name": "Sample",
+				"plural": "Samples"
+			}
+		],
+		"chartCounts": [{
+			"graphql": "_subject_count",
+			"name": "Subject"
+		}],
+		"projectDetails": "boardCounts"
+	},
+	"components": {
+		"appName": "NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-Space (AnVIL)",
+		"index": {
+			"introduction": {
+				"heading": "The AnVIL",
+				"text": "The AnVIL supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer. The data commons supports cross-project analyses by harmonizing data from different projects through the collaborative development of a data dictionary, providing an API for data queries and download, and providing a cloud-based analysis workspace with rich tools and resources.",
+				"link": "/submission"
+			},
+			"buttons": [{
+					"name": "Define Data Field",
+					"icon": "anvil-planning",
+					"body": "The AnVIL defines the data in a general way. Please study the dictionary before you start browsing.",
+					"link": "/DD",
+					"label": "Learn more",
+					"color": "#035C94"
+				},
+				{
+					"name": "Explore Data",
+					"icon": "anvil-explore",
+					"body": "The Exploration Page gives you insights and a clear overview under selected factors.",
+					"link": "/explorer",
+					"label": "Explore data",
+					"color": "#035C94"
+				},
+				{
+					"name": "Analyze Data",
+					"icon": "anvil-analyze",
+					"body": "Analyze your selected subjects using Jupyter Notebooks in our secure cloud environment",
+					"link": "#hostname#workspace/",
+					"label": "Run analysis",
+					"color": "#035C94"
+				}
+			],
+			"homepageChartNodes": [{
+					"node": "subject",
+					"name": "Subjects"
+				},
+				{
+					"node": "sample",
+					"name": "Samples"
+				}
+			]
+		},
+		"navigation": {
+			"title": "The AnVIL",
+			"items": [{
+					"icon": "dictionary",
+					"link": "/DD",
+					"color": "#035C94",
+					"name": "Dictionary"
+				},
+				{
+					"icon": "exploration",
+					"link": "/explorer",
+					"color": "#035C94",
+					"name": "Exploration"
+				},
+				{
+					"icon": "workspace",
+					"link": "#hostname#workspace/",
+					"color": "#035C94",
+					"name": "Workspace"
+				},
+				{
+					"icon": "profile",
+					"link": "/identity",
+					"color": "#035C94",
+					"name": "Profile"
+				}
+			]
+		},
+		"login": {
+			"title": "NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-Space (AnVIL)",
+			"subTitle": "Explore, Analyze, and Share Data",
+			"text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
+			"contact": "If you have any questions about access or the registration process, please contact ",
+			"email": "support@datacommons.io"
+		},
+		"categorical9Colors": ["#035C94", "#7EBAC0", "#AEEBF2", "#E0DD10", "#40476D", "#FFA630", "#AE8799", "#035C94", "#462255"],
+		"categorical2Colors": ["#035C94", "#7EBAC0"]
+	},
+	"featureFlags": {
+		"explorer": true
+	},
+	"explorerConfig": [{
+			"tabTitle": "Data",
+			"charts": {
+				"project_id": {
+					"chartType": "count",
+					"title": "Projects"
+				},
+				"node_id": {
+					"chartType": "count",
+					"title": "Subjects"
+				},
+				"sex": {
+					"chartType": "pie",
+					"title": "Sex"
+				},
+				"ancestry": {
+					"chartType": "bar",
+					"title": "Ancestry"
+				}
+			},
+			"filters": {
+				"tabs": [{
+					"title": "Projects",
+					"fields": [
+						"project_id",
+						"project_short_name",
+						"project_dbgap_accession_number",
+						"project_dbgap_consent_text",
+						"project_dbgap_phs",
+						"project_name"
+					]
+				}, {
+					"title": "Subject",
+					"fields": [
+						"anvil_project_id",
+						"sex",
+						"age_value",
+						"ancestry",
+						"disease_description",
+						"phenotype_present",
+						"phenotype_absent",
+						"disease_id",
+						"solve_state",
+						"congenital_status",
+						"age_of_onset",
+						"phenotype_group"
+					]
+				}, {
+					"title": "Sample",
+					"fields": [
+						"sample_provider",
+						"tissue_affected_status",
+						"tissue_type",
+						"sample_type",
+						"original_material_type"
+					]
+				}, {
+					"title": "Sequencing",
+					"fields": [
+						"library_prep_kit_method",
+						"exome_capture_platform",
+						"capture_region_bed_file",
+						"reference_genome_build",
+						"sequencing_assay",
+						"alignment_method",
+						"data_processing_pipeline"
+					]
+				}]
+			},
+			"table": {
+				"enabled": true,
+				"fields": [
+					"project_id",
+					"anvil_project_id",
+					"ancestry",
+					"sex",
+					"age_value",
+					"phenotype_group",
+					"_samples_count",
+					"_sequencings_count"
+				]
+			},
+			"buttons": [{
+					"enabled": true,
+					"type": "export",
+					"title": "Export All to Terra",
+					"rightIcon": "external-link"
+				},
+				{
+					"enabled": true,
+					"type": "export-to-pfb",
+					"title": "Export to PFB",
+					"leftIcon": "datafile",
+					"rightIcon": "download"
+				},
+				{
+					"enabled": true,
+					"type": "export-to-workspace",
+					"title": "Export to Workspace",
+					"leftIcon": "datafile",
+					"rightIcon": "download"
+				}
+			],
+			"guppyConfig": {
+				"dataType": "subject",
+				"nodeCountTitle": "Subjects",
+				"fieldMapping": [{
+						"field": "disease_id",
+						"name": "Disease ID"
+					},
+					{
+						"field": "age_of_onset",
+						"name": "Age of Onset"
+					},
+					{
+						"field": "project_dbgap_accession_number",
+						"name": "Project dbGaP Accession Number"
+					},
+					{
+						"field": "project_dbgap_consent_text",
+						"name": "Project dbGaP Consent Text"
+					},
+					{
+						"field": "project_dbgap_phs",
+						"name": "Project dbGaP Phs"
+					}
+				],
+				"manifestMapping": {
+					"resourceIndexType": "file",
+					"resourceIdField": "object_id",
+					"referenceIdFieldInResourceIndex": "_subject_id",
+					"referenceIdFieldInDataIndex": "_subject_id"
+				},
+				"accessibleFieldCheckList": ["project_id"],
+				"accessibleValidationField": "project_id"
+			},
+			"getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/",
+			"terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
+		},
+		{
+			"tabTitle": "File",
+			"charts": {
+				"data_type": {
+					"chartType": "stackedBar",
+					"title": "File Type"
+				},
+				"data_format": {
+					"chartType": "stackedBar",
+					"title": "File Format"
+				}
+			},
+			"filters": {
+				"tabs": [{
+					"title": "File",
+					"fields": [
+						"project_id",
+						"data_category",
+						"data_type",
+						"data_format",
+						"analyte_type",
+						"sequencing_assay"
+					]
+				}]
+			},
+			"table": {
+				"enabled": true,
+				"fields": [
+					"project_id",
+					"subject_submitter_id",
+					"file_name",
+					"data_format",
+					"data_type",
+					"data_category",
+					"file_size",
+					"submitter_id",
+					"object_id",
+					"md5sum"
+				]
+			},
+			"guppyConfig": {
+				"dataType": "file",
+				"fieldMapping": [{
+					"field": "object_id",
+					"name": "GUID"
+				}],
+				"nodeCountTitle": "Files",
+				"manifestMapping": {
+					"resourceIndexType": "subject",
+					"resourceIdField": "_subject_id",
+					"referenceIdFieldInResourceIndex": "object_id",
+					"referenceIdFieldInDataIndex": "object_id"
+				},
+				"accessibleFieldCheckList": ["project_id"],
+				"accessibleValidationField": "project_id",
+				"downloadAccessor": "object_id"
+			},
+			"buttons": [{
+					"enabled": true,
+					"type": "export-files-to-workspace",
+					"title": "Export to Workspace",
+					"leftIcon": "datafile",
+					"rightIcon": "download"
+				},
+				{
+					"enabled": true,
+					"type": "export-files-to-pfb",
+					"title": "Export All to PFB",
+					"rightIcon": "external-link",
+					"tooltipText": "You have not selected any subjects to export. Please use the checkboxes on the left to select specific cases you would like to export."
+				},
+				{
+					"enabled": true,
+					"type": "export-files",
+					"title": "Export All to Terra",
+					"rightIcon": "external-link",
+					"tooltipText": "You have not selected any subjects to export. Please use the checkboxes on the left to select specific cases you would like to export."
+				}
+			],
+			"enableLimitedFilePFBExport": {
+				"sourceNodeField": "source_node"
+			},
+			"terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data",
+			"dropdowns": {}
+		},
+		{
+			"tabTitle": "Downloadable",
+			"adminAppliedPreFilters": {
+				"project_id": {
+					"selectedValues": ["DEV-QA"]
+				}
+			},
+			"charts": {
+				"data_type": {
+					"chartType": "stackedBar",
+					"title": "File Type"
+				},
+				"data_format": {
+					"chartType": "stackedBar",
+					"title": "File Format"
+				}
+			},
+			"filters": {
+				"tabs": [{
+					"title": "File",
+					"fields": [
+						"project_id",
+						"data_category",
+						"data_type",
+						"data_format",
+						"analyte_type",
+						"sequencing_assay"
+					]
+				}, {
+					"title": "Subject",
+					"fields": [
+						"anvil_project_id",
+						"sex",
+						"age_value",
+						"ancestry",
+						"disease_description",
+						"phenotype_present",
+						"phenotype_absent",
+						"disease_id",
+						"solve_state",
+						"congenital_status",
+						"age_of_onset",
+						"phenotype_group"
+					]
+				}, {
+					"title": "Sample",
+					"fields": [
+						"sample_provider",
+						"tissue_affected_status",
+						"tissue_type",
+						"sample_type",
+						"original_material_type"
+					]
+				}, {
+					"title": "Sequencing",
+					"fields": [
+						"library_prep_kit_method",
+						"exome_capture_platform",
+						"capture_region_bed_file",
+						"reference_genome_build",
+						"sequencing_assay",
+						"alignment_method",
+						"data_processing_pipeline"
+					]
+				}]
+			},
+			"table": {
+				"enabled": true,
+				"fields": [
+					"project_id",
+					"subject_submitter_id",
+					"file_name",
+					"data_format",
+					"data_type",
+					"data_category",
+					"file_size",
+					"submitter_id",
+					"object_id",
+					"md5sum"
+				]
+			},
+			"guppyConfig": {
+				"dataType": "file",
+				"fieldMapping": [{
+					"field": "object_id",
+					"name": "GUID"
+				}],
+				"nodeCountTitle": "Files",
+				"manifestMapping": {
+					"resourceIndexType": "subject",
+					"resourceIdField": "_subject_id",
+					"referenceIdFieldInResourceIndex": "object_id",
+					"referenceIdFieldInDataIndex": "object_id"
+				},
+				"accessibleFieldCheckList": ["project_id"],
+				"accessibleValidationField": "project_id",
+				"downloadAccessor": "object_id"
+			},
+			"buttons": [{
+					"enabled": true,
+					"type": "file-manifest",
+					"title": "Download Manifest",
+					"leftIcon": "datafile",
+					"rightIcon": "download",
+					"fileName": "file-manifest.json"
+				},
+				{
+					"enabled": true,
+					"type": "export-files-to-workspace",
+					"title": "Export to Workspace",
+					"leftIcon": "datafile"
+				},
+				{
+					"enabled": true,
+					"type": "export-files-to-pfb",
+					"title": "Export All to PFB",
+					"rightIcon": "external-link",
+					"tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
+				},
+				{
+					"enabled": true,
+					"type": "export-files",
+					"title": "Export All to Terra",
+					"rightIcon": "external-link",
+					"tooltipText": "You have not selected any files to export. Please use the checkboxes on the left to select specific files you would like to export."
+				}
+			],
+			"enableLimitedFilePFBExport": {
+				"sourceNodeField": "source_node"
+			},
+			"terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data"
+		}
+	]
 }

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -6,7 +6,7 @@
   "versions": {
     "arborist": "quay.io/cdis/arborist:2020.12",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "covid19-etl": "quay.io/cdis/covid19-etl:4.5.6",
+    "covid19-etl": "quay.io/cdis/covid19-etl:4.6.0",
     "nb-etl": "quay.io/cdis/covid19-nb-etl:4.4.4",
     "fence": "quay.io/cdis/fence:2020.12",
     "indexd": "quay.io/cdis/indexd:2020.12",


### PR DESCRIPTION
Switching Downloadable tab in the Data Explorer to be based on file index. Currently deployed in https://qa-anvil.planx-pla.net/explorer

This PR is for: https://ctds-planx.atlassian.net/browse/PXP-7385

### Environments
- Affects QA Anvil.

### Description of changes
- Changes "Downloadable" tab in Data Explorer to be based on the Files tab rather than the Subjects tab.