### PR TITLE
chore(qa): Adjust scaling settings for portal and presigned url fence pods

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -306,17 +306,15 @@
       "strategy": "auto"
     },
     "portal": {
-      "strategy": "auto",
-      "min": 1,
-      "max": 2
+      "strategy": "auto"
     },
     "fence": {
       "strategy": "auto"
     },
     "presigned-url-fence": {
       "strategy": "auto",
-      "min": 3,
-      "max": 5,
+      "min": 2,
+      "max": 3,
       "targetCpu": 40
     },
     "indexd": {

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -303,17 +303,15 @@
       "strategy": "auto"
     },
     "portal": {
-      "strategy": "auto",
-      "min": 1,
-      "max": 2
+      "strategy": "auto"
     },
     "fence": {
       "strategy": "auto"
     },
     "presigned-url-fence": {
       "strategy": "auto",
-      "min": 3,
-      "max": 5,
+      "min": 2,
+      "max": 3,
       "targetCpu": 40
     },
     "indexd": {

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -299,17 +299,15 @@
       "strategy": "auto"
     },
     "portal": {
-      "strategy": "auto",
-      "min": 1,
-      "max": 2
+      "strategy": "auto"
     },
     "fence": {
       "strategy": "auto"
     },
     "presigned-url-fence": {
       "strategy": "auto",
-      "min": 3,
-      "max": 5,
+      "min": 2,
+      "max": 3,
       "targetCpu": 40
     },
     "indexd": {

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -307,17 +307,15 @@
       "strategy": "auto"
     },
     "portal": {
-      "strategy": "auto",
-      "min": 1,
-      "max": 2
+      "strategy": "auto"
     },
     "fence": {
       "strategy": "auto"
     },
     "presigned-url-fence": {
       "strategy": "auto",
-      "min": 3,
-      "max": 5,
+      "min": 2,
+      "max": 3,
       "targetCpu": 40
     },
     "indexd": {

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -307,17 +307,15 @@
       "strategy": "auto"
     },
     "portal": {
-      "strategy": "auto",
-      "min": 1,
-      "max": 2
+      "strategy": "auto"
     },
     "fence": {
       "strategy": "auto"
     },
     "presigned-url-fence": {
       "strategy": "auto",
-      "min": 3,
-      "max": 5,
+      "min": 2,
+      "max": 3,
       "targetCpu": 40
     },
     "indexd": {


### PR DESCRIPTION
There's a mysterious portal pod that shows up delaying the whole `k8sReset` process, this new configuration should avoid that and speed things up significantly.

Also, we should lower the number of replicas for `presigned-url-fence` pods for frugality purposes.