### PR TITLE
chore: updating portal and auspice versions in qa-covid19

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -14,7 +14,7 @@
     "pidgin": "quay.io/cdis/pidgin:2021.01",
     "revproxy": "quay.io/cdis/nginx:2021.01",
     "sheepdog": "quay.io/cdis/sheepdog:2021.01",
-    "portal": "quay.io/cdis/data-portal:2.43.0",
+    "portal": "quay.io/cdis/data-portal:2.43.2",
     "tube": "quay.io/cdis/tube:2021.01",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2021.01",
@@ -26,7 +26,7 @@
     "guppy": "quay.io/cdis/guppy:0.10.0",
     "manifestservice": "quay.io/cdis/manifestservice:2021.01",
     "dashboard": "quay.io/cdis/gen3-statics:2021.01",
-    "auspice": "quay.io/cdis/gen3-auspice:v2.16.gen3.3",
+    "auspice": "quay.io/cdis/gen3-auspice:v2.16.gen3.4",
     "sower": "quay.io/cdis/sower:2021.01",
     "metadata": "quay.io/cdis/metadata-service:2021.01"
   },


### PR DESCRIPTION
Updating versions in QA_COVID19

`2.43.2` for portal
`v2.16.gen3.4` for auspice