### PR TITLE
chore(manifest): update Auspice to 2.16.gen3.6

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -26,7 +26,7 @@
     "guppy": "quay.io/cdis/guppy:0.10.0",
     "manifestservice": "quay.io/cdis/manifestservice:2021.01",
     "dashboard": "quay.io/cdis/gen3-statics:2021.01",
-    "auspice": "quay.io/cdis/gen3-auspice:v2.16.gen3.4",
+    "auspice": "quay.io/cdis/gen3-auspice:v2.16.gen3.6",
     "sower": "quay.io/cdis/sower:2021.01",
     "metadata": "quay.io/cdis/metadata-service:2021.01"
   },


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://occ-data.atlassian.net/browse/COV-636
### Environments
QA-PRC

### Description of changes
Update Auspice version to point to new Quay image that includes new trees for global and IL visualizations.