### PR TITLE
chore(manifest): upgrade gen3-fuse to new version

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-11T18:01:27Z",
+  "generated_at": "2021-02-10T19:11:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -163,14 +163,6 @@
         "hashed_secret": "51de2b835bd35a67eb32dbcd3d77d4b96e5aa39d",
         "is_verified": false,
         "line_number": 8484,
-        "type": "Secret Keyword"
-      }
-    ],
-    "qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json": [
-      {
-        "hashed_secret": "e94cc2a86b04ad4ddc98fcbf91ed236437939d47",
-        "is_verified": false,
-        "line_number": 86,
         "type": "Secret Keyword"
       }
     ],

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -236,7 +236,7 @@
       },
       "gen3fusesidecar": {
         "name": "mariner-gen3fusesidecar",
-        "image": "quay.io/cdis/gen3fuse-sidecar:2021.01",
+        "image": "quay.io/cdis/gen3fuse-sidecar:2021.0.2.3",
         "pull_policy": "always",
         "command": [
           "/bin/bash",

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -236,7 +236,7 @@
       },
       "gen3fusesidecar": {
         "name": "mariner-gen3fusesidecar",
-        "image": "quay.io/cdis/gen3fuse-sidecar:2021.0.2.3",
+        "image": "quay.io/cdis/gen3fuse-sidecar:0.2.3",
         "pull_policy": "always",
         "command": [
           "/bin/bash",

--- a/qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2021.01",
+    "image": "quay.io/cdis/gen3fuse-sidecar:2021.0.2.3",
     "env": {
       "NAMESPACE": "qa-covid19",
       "HOSTNAME": "qa-covid19.planx-pla.net"

--- a/qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2021.0.2.3",
+    "image": "quay.io/cdis/gen3fuse-sidecar:0.2.3",
     "env": {
       "NAMESPACE": "qa-covid19",
       "HOSTNAME": "qa-covid19.planx-pla.net"


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
QA-PRC

### Description of changes
Upgrade gen3-fuse to version 2021.0.2.3 to include fix for adding sleep/retry logic to prevent the fuse sidecar from erroring out each time the workspace pod triggers an auto scaling. 