### PR TITLE
Chore/update qa dcp

### DIFF
--- a/qa-dcp.planx-pla.net/etlMapping.yaml
+++ b/qa-dcp.planx-pla.net/etlMapping.yaml
@@ -125,6 +125,7 @@ mappings:
             fn: set
           - name: file_count
             src: file_id
+            alternate_src: _file_id
             fn: count
   - name: qa-dcp_file
     doc_type: file
@@ -150,3 +151,5 @@ mappings:
             src: id
             fn: set
           - name: project_id
+
+

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -7,27 +7,27 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2021.02",
+    "arborist": "quay.io/cdis/arborist:integration202102",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2021.02",
-    "indexd": "quay.io/cdis/indexd:2021.02",
-    "peregrine": "quay.io/cdis/peregrine:2021.02",
-    "pidgin": "quay.io/cdis/pidgin:2021.02",
-    "revproxy": "quay.io/cdis/nginx:2021.02",
-    "sheepdog": "quay.io/cdis/sheepdog:2021.02",
-    "portal": "quay.io/cdis/data-portal:feat_index-scoped-tiered-access",
+    "fence": "quay.io/cdis/fence:integration202102",
+    "indexd": "quay.io/cdis/indexd:integration202102",
+    "peregrine": "quay.io/cdis/peregrine:integration202102",
+    "pidgin": "quay.io/cdis/pidgin:integration202102",
+    "revproxy": "quay.io/cdis/nginx:integration202102",
+    "sheepdog": "quay.io/cdis/sheepdog:integration202102",
+    "portal": "quay.io/cdis/data-portal:integration202102",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "quay.io/cdis/gen3-spark:2021.02",
-    "tube": "quay.io/cdis/tube:2021.02",
-    "guppy": "quay.io/cdis/guppy:2021.02",
-    "sower": "quay.io/cdis/sower:2021.02",
-    "hatchery": "quay.io/cdis/hatchery:2021.02",
+    "spark": "quay.io/cdis/gen3-spark:integration202102",
+    "tube": "quay.io/cdis/tube:integration202102",
+    "guppy": "quay.io/cdis/guppy:integration202102",
+    "sower": "quay.io/cdis/sower:integration202102",
+    "hatchery": "quay.io/cdis/hatchery:integration202102",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "wts": "quay.io/cdis/workspace-token-service:2021.02",
-    "manifestservice": "quay.io/cdis/manifestservice:2021.02",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2021.02",
-    "metadata": "quay.io/cdis/metadata-service:2021.02",
-    "dashboard": "quay.io/cdis/gen3-statics:2021.02"
+    "wts": "quay.io/cdis/workspace-token-service:integration202102",
+    "manifestservice": "quay.io/cdis/manifestservice:integration202102",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:integration202102",
+    "metadata": "quay.io/cdis/metadata-service:integration202102",
+    "dashboard": "quay.io/cdis/gen3-statics:integration202102"
   },
   "google": {
     "enabled": "yes"
@@ -43,7 +43,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/metadata-manifest-ingestion:2021.02",
+        "image": "quay.io/cdis/metadata-manifest-ingestion:integration202102",
         "pull_policy": "Always",
         "env": [
           {
@@ -83,7 +83,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/get-dbgap-metadata:2021.02",
+        "image": "quay.io/cdis/get-dbgap-metadata:integration202102",
         "pull_policy": "Always",
         "env": [],
         "volumeMounts": [
@@ -113,7 +113,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/manifest-indexing:2021.02",
+        "image": "quay.io/cdis/manifest-indexing:integration202102",
         "pull_policy": "Always",
         "env": [
           {
@@ -153,7 +153,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/download-indexd-manifest:2021.02",
+        "image": "quay.io/cdis/download-indexd-manifest:integration202102",
         "pull_policy": "Always",
         "env": [
           {
@@ -192,7 +192,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:2021.02",
+        "image": "quay.io/cdis/pelican-export:integration202102",
         "pull_policy": "Always",
         "env": [
           {
@@ -256,7 +256,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:2021.02",
+        "image": "quay.io/cdis/pelican-export:integration202102",
         "pull_policy": "Always",
         "env": [
           {
@@ -322,7 +322,7 @@
   ],
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2021.02"
+      "indexing": "quay.io/cdis/indexs3client:integration202102"
     }
   },
   "global": {

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -19,7 +19,7 @@
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2021.02",
     "tube": "quay.io/cdis/tube:2021.02",
-    "guppy": "quay.io/cdis/guppy:2021.02",
+    "guppy": "quay.io/cdis/guppy:feat_per-index-tiered-access",
     "sower": "quay.io/cdis/sower:2021.02",
     "hatchery": "quay.io/cdis/hatchery:2021.02",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -7,27 +7,27 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:integration202102",
+    "arborist": "quay.io/cdis/arborist:2021.02",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:integration202102",
-    "indexd": "quay.io/cdis/indexd:integration202102",
-    "peregrine": "quay.io/cdis/peregrine:integration202102",
-    "pidgin": "quay.io/cdis/pidgin:integration202102",
-    "revproxy": "quay.io/cdis/nginx:integration202102",
-    "sheepdog": "quay.io/cdis/sheepdog:integration202102",
-    "portal": "quay.io/cdis/data-portal:integration202102",
+    "fence": "quay.io/cdis/fence:2021.02",
+    "indexd": "quay.io/cdis/indexd:2021.02",
+    "peregrine": "quay.io/cdis/peregrine:2021.02",
+    "pidgin": "quay.io/cdis/pidgin:2021.02",
+    "revproxy": "quay.io/cdis/nginx:2021.02",
+    "sheepdog": "quay.io/cdis/sheepdog:2021.02",
+    "portal": "quay.io/cdis/data-portal:feat_index-scoped-tiered-access",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "quay.io/cdis/gen3-spark:integration202102",
-    "tube": "quay.io/cdis/tube:integration202102",
-    "guppy": "quay.io/cdis/guppy:integration202102",
-    "sower": "quay.io/cdis/sower:integration202102",
-    "hatchery": "quay.io/cdis/hatchery:integration202102",
+    "spark": "quay.io/cdis/gen3-spark:2021.02",
+    "tube": "quay.io/cdis/tube:2021.02",
+    "guppy": "quay.io/cdis/guppy:2021.02",
+    "sower": "quay.io/cdis/sower:2021.02",
+    "hatchery": "quay.io/cdis/hatchery:2021.02",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "wts": "quay.io/cdis/workspace-token-service:integration202102",
-    "manifestservice": "quay.io/cdis/manifestservice:integration202102",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:integration202102",
-    "metadata": "quay.io/cdis/metadata-service:integration202102",
-    "dashboard": "quay.io/cdis/gen3-statics:integration202102"
+    "wts": "quay.io/cdis/workspace-token-service:2021.02",
+    "manifestservice": "quay.io/cdis/manifestservice:2021.02",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2021.02",
+    "metadata": "quay.io/cdis/metadata-service:2021.02",
+    "dashboard": "quay.io/cdis/gen3-statics:2021.02"
   },
   "google": {
     "enabled": "yes"
@@ -43,7 +43,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/metadata-manifest-ingestion:integration202102",
+        "image": "quay.io/cdis/metadata-manifest-ingestion:2021.02",
         "pull_policy": "Always",
         "env": [
           {
@@ -83,7 +83,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/get-dbgap-metadata:integration202102",
+        "image": "quay.io/cdis/get-dbgap-metadata:2021.02",
         "pull_policy": "Always",
         "env": [],
         "volumeMounts": [
@@ -113,7 +113,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/manifest-indexing:integration202102",
+        "image": "quay.io/cdis/manifest-indexing:2021.02",
         "pull_policy": "Always",
         "env": [
           {
@@ -153,7 +153,7 @@
       "serviceAccountName": "jobs-qa-dcp-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/download-indexd-manifest:integration202102",
+        "image": "quay.io/cdis/download-indexd-manifest:2021.02",
         "pull_policy": "Always",
         "env": [
           {
@@ -192,7 +192,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:integration202102",
+        "image": "quay.io/cdis/pelican-export:2021.02",
         "pull_policy": "Always",
         "env": [
           {
@@ -256,7 +256,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:integration202102",
+        "image": "quay.io/cdis/pelican-export:2021.02",
         "pull_policy": "Always",
         "env": [
           {
@@ -322,7 +322,7 @@
   ],
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:integration202102"
+      "indexing": "quay.io/cdis/indexs3client:2021.02"
     }
   },
   "global": {

--- a/qa-dcp.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-dcp.planx-pla.net/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:2021.02",
+    "image": "quay.io/cdis/gen3fuse-sidecar:integration202102",
     "env": {
       "NAMESPACE": "qa-dcp",
       "HOSTNAME": "qa-dcp.planx-pla.net"

--- a/qa-dcp.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-dcp.planx-pla.net/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "quay.io/cdis/gen3fuse-sidecar:integration202102",
+    "image": "quay.io/cdis/gen3fuse-sidecar:2021.02",
     "env": {
       "NAMESPACE": "qa-dcp",
       "HOSTNAME": "qa-dcp.planx-pla.net"

--- a/qa-dcp.planx-pla.net/portal/gitops.json
+++ b/qa-dcp.planx-pla.net/portal/gitops.json
@@ -325,7 +325,6 @@
     },
     "guppyConfig": {
       "dataType": "subject",
-      "tierAccessLevel": "libre",
       "nodeCountTitle": "Subjects",
       "fileCountField": "file_count",
       "fieldMapping": [
@@ -528,7 +527,6 @@
     },
     "guppyConfig": {
       "dataType": "file",
-      "tierAccessLevel": "private",
       "fieldMapping": [
         {
           "field": "object_id",

--- a/qa-dcp.planx-pla.net/portal/gitops.json
+++ b/qa-dcp.planx-pla.net/portal/gitops.json
@@ -325,6 +325,7 @@
     },
     "guppyConfig": {
       "dataType": "subject",
+      "tierAccessLevel": "libre",
       "nodeCountTitle": "Subjects",
       "fileCountField": "file_count",
       "fieldMapping": [
@@ -527,6 +528,7 @@
     },
     "guppyConfig": {
       "dataType": "file",
+      "tierAccessLevel": "private",
       "fieldMapping": [
         {
           "field": "object_id",


### PR DESCRIPTION
- Updating qa-dcp services to 2021.02 release version
- Testing index-scoped tiered-access (data-portal and guppy changes)