### PR TITLE
update auspice v2.16.gen3.10

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -26,7 +26,7 @@
     "guppy": "quay.io/cdis/guppy:2021.02",
     "manifestservice": "quay.io/cdis/manifestservice:2021.02",
     "dashboard": "quay.io/cdis/gen3-statics:2021.02",
-    "auspice": "quay.io/cdis/gen3-auspice:v2.16.gen3.9",
+    "auspice": "quay.io/cdis/gen3-auspice:v2.16.gen3.10",
     "sower": "quay.io/cdis/sower:2021.02",
     "metadata": "quay.io/cdis/metadata-service:2021.02"
   },


### PR DESCRIPTION
update auspice to v2.16.gen3.10. This version contains Illinois tree with 1041 SIU sequences.

Link to Jira ticket if there is one:
https://occ-data.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=COV&modal=detail&selectedIssue=COV-732&assignee=5bedb7bbe17eda2b3fdd0270
### Environments


### Description of changes
