### PR TITLE
chore(ci): Remove dashboard from jenkins-niaid

### DIFF
--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -30,7 +30,6 @@
     "sower": "quay.io/cdis/sower:master",
     "hatchery": "quay.io/cdis/hatchery:master",
     "metadata": "quay.io/cdis/metadata-service:master",
-    "dashboard": "quay.io/cdis/gen3-statics:master",
     "requestor": "quay.io/cdis/requestor:master"
   },
   "arborist": {


### PR DESCRIPTION
Remove `dashboard` from `jenkins-niaid` due to mysterious issue with secrets mgmt that occurs intermittently.