### PR TITLE
chore/update_covid19-portal: update covid19 data-portal image to 2.47.1

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -14,7 +14,7 @@
     "pidgin": "quay.io/cdis/pidgin:2021.02",
     "revproxy": "quay.io/cdis/nginx:2021.02",
     "sheepdog": "quay.io/cdis/sheepdog:2021.02",
-    "portal": "quay.io/cdis/data-portal:2.47.0",
+    "portal": "quay.io/cdis/data-portal:2.47.1",
     "tube": "quay.io/cdis/tube:2021.02",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2021.02",


### PR DESCRIPTION
[COV-806](https://occ-data.atlassian.net/browse/COV-806)

### Environments
PRC

### Description of changes
  - fix Homepage maps sometimes showing no data/ gray (#821)
  - make gray slightly darker to pass WCAG AAA accessibility guidelines (#820)
  - allow charts to wrap when they do not have room to display (#820)
  - update stylelint to newer version (#820)
  - Update @gen3/ui-component dependency to version 0.6.6 (#820)
  - Update @gen3/guppy dependency to version 0.11.2 (#820)