### PR TITLE
chore/update_covid19-portal: update covid19 data-portal image to 2.48.0

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -14,7 +14,7 @@
     "pidgin": "quay.io/cdis/pidgin:2021.03",
     "revproxy": "quay.io/cdis/nginx:2021.03",
     "sheepdog": "quay.io/cdis/sheepdog:2021.03",
-    "portal": "quay.io/cdis/data-portal:2.47.1",
+    "portal": "quay.io/cdis/data-portal:2.48.0",
     "tube": "quay.io/cdis/tube:2021.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2021.03",

--- a/qa-covid19.planx-pla.net/portal/gitops.css
+++ b/qa-covid19.planx-pla.net/portal/gitops.css
@@ -50,7 +50,6 @@
 
 /* Buttons */
 
-.data-dictionary__switch-button--active,
 .popup__title {
   background-color: var(--primary-color);
 }


### PR DESCRIPTION
### Environments
PRC

### Description of changes
  - change the way activeTab is set so that it always highlights which page the 
    user is on (#823)
  - refactor navigation to work with current standards (#823)
  - make data dictionary button color will honor the secondary button color 
  (#822)
  - envs with customized color schemes no longer need to overwrite dictionary 
  button color in their `gitops.css` (#822)
  
  