### PR TITLE
chore/update_covid19-portal: update covid19 data-portal image to 2.49.0

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -14,7 +14,7 @@
     "pidgin": "quay.io/cdis/pidgin:2021.03",
     "revproxy": "quay.io/cdis/nginx:2021.03",
     "sheepdog": "quay.io/cdis/sheepdog:2021.03",
-    "portal": "quay.io/cdis/data-portal:2.48.0",
+    "portal": "quay.io/cdis/data-portal:2.49.0",
     "tube": "quay.io/cdis/tube:2021.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "quay.io/cdis/gen3-spark:2021.03",
@@ -171,7 +171,8 @@
     ],
     "config_index": "qa-covid19_array-config",
     "auth_filter_field": "auth_resource_path",
-    "aggs_include_missing_data": false
+    "aggs_include_missing_data": false,
+    "filter_field_hide_empty": true
   },
   "mariner": {
     "storage": {

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -171,8 +171,7 @@
     ],
     "config_index": "qa-covid19_array-config",
     "auth_filter_field": "auth_resource_path",
-    "aggs_include_missing_data": false,
-    "filter_field_hide_empty": true
+    "aggs_include_missing_data": false
   },
   "mariner": {
     "storage": {


### PR DESCRIPTION
### Environments
PRC

### Description of changes
- make map legend slightly transparent (#827)
- Fixed Pentest Info Disclosure: Support Packages & Config Files 
  vulnerability (#824)
- Fixed Pentest Outdated Nginx Version vulnerability (#824)
- Use NPM 7 in dockerfile (#824)
- Use Ubuntu 20.04 as base image in dockerfile (#824)
- Use Nginx 1.18 in dockerfile (#824)