### PR TITLE
Changed restart policy for a mariner job task

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -200,7 +200,7 @@
         "labels": {
           "app": "mariner-task"
         },
-        "restart_policy": "never"
+        "restart_policy": "on_failure"
       }
     },
     "containers": {


### PR DESCRIPTION
Jira [PXP-7606](https://ctds-planx.atlassian.net/browse/PXP-7606)

### Environments
- qa-covid19

### Description of changes
- Changed restart policy for Mariner task to prevent infinite spawn of k8 pods.