### PR TITLE
turn on ArboristUI on jenkins-niaid

### DIFF
--- a/jenkins-niaid.planx-pla.net/portal/gitops.json
+++ b/jenkins-niaid.planx-pla.net/portal/gitops.json
@@ -141,6 +141,7 @@
       ]
     }
   ],
+  "useArboristUI": true,
   "arrangerConfig": {
     "charts": {
       "project_id": {


### PR DESCRIPTION
adding `"useArboristUI": true` in portal config for jenkins-niaid
