### PR TITLE
updating the auto-label

### DIFF
--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "jenkins-niaid": ["qa-niaid.planx-pla.net/"]"
+    "jenkins-niaid": ["qa-niaid.planx-pla.net/"]
   }
 }

--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-  "jenkins-niaid": ["qa-niaid.planx-pla.net/"]"
+    "jenkins-niaid": ["qa-niaid.planx-pla.net/"]"
   }
 }

--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,3 +1,4 @@
 {
-  "rules": ""
+  "rules": 
+  "jenkins-niaid": ["qa-niaid.planx-pla.net/"]"
 }

--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,4 +1,5 @@
 {
-  "rules": 
+  "rules": {
   "jenkins-niaid": ["qa-niaid.planx-pla.net/"]"
+  }
 }


### PR DESCRIPTION
The commit in auto-label would allow to run `qa-niaid` related PR on `jenkins-niaid` as study-viewer feature is enabled on `jenkins-niaid` only

So with this the studyViewer test would run on every `qa-niaid` PR
