### PR TITLE
chore/update_covid19-portal: update covid19 data-portal image to 2.50.0

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -18,7 +18,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.03",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.03",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.03",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2.49.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2.50.0",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.03",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.03",

--- a/qa-covid19.planx-pla.net/portal/gitops.json
+++ b/qa-covid19.planx-pla.net/portal/gitops.json
@@ -137,7 +137,8 @@
   "featureFlags": {
     "explorer": true,
     "analysis": true,
-    "explorerPublic": true
+    "explorerPublic": true,
+    "explorerHideEmptyFilterSection": true
   },
   "analysisTools": [],
   "explorerConfig": [


### PR DESCRIPTION
### Environments
PRC

### Description of changes
- update covid19 data-portal image to 2.50.0 and set explorerHideEmptyFilterSection flag for PRC
- add hideEmptyFilterSection flag and functionality to hide empty filter sections  (#833)
- Change explorerConfig.table.fields to optional (#810)
- Add local portal documentation to data-portal repo (#831)
- Update the path to the PRC top10 chart data (#832)