### PR TITLE
feat/newGuppyFilter: update guppy and adjust flags

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -26,7 +26,7 @@
     "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.03",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2021.03",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2021.03",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:0.13.0",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.03",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.03",
     "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.1",
@@ -173,8 +173,7 @@
       }
     ],
     "config_index": "qa-covid19_array-config",
-    "auth_filter_field": "auth_resource_path",
-    "aggs_include_missing_data": false
+    "auth_filter_field": "auth_resource_path"
   },
   "mariner": {
     "storage": {

--- a/qa-covid19.planx-pla.net/portal/gitops.json
+++ b/qa-covid19.planx-pla.net/portal/gitops.json
@@ -138,7 +138,8 @@
     "explorer": true,
     "analysis": true,
     "explorerPublic": true,
-    "explorerHideEmptyFilterSection": true
+    "explorerHideEmptyFilterSection": true,
+    "explorerFilterValuesToHide": ["no data"]
   },
   "analysisTools": [],
   "explorerConfig": [


### PR DESCRIPTION
### Environments
PRC

### Description of changes
- Update @gen3/guppy dependency to version 0.13.0 (#837)
- set flags to show "no data" and the use new flags to hide "no data" in filters
- add explorerHideDataFilter and pass it through to guppy (#837)
- Data Explorer state can now be loaded and unloaded to and from the page 
    URL. This feature is disabled by default; it can be enabled with the 
    `explorerStoreFilterInURL` featureFlag in the portal config. (#807)
