### PR TITLE
covid jupyter image 1.2.0

### DIFF
--- a/qa-covid19.planx-pla.net/manifests/hatchery/jupyter-covid19.yaml
+++ b/qa-covid19.planx-pla.net/manifests/hatchery/jupyter-covid19.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
    webapp:
-      image: "quay.io/cdis/jupyter-covid19:master"
+      image: "quay.io/cdis/jupyter-covid19:jupyter-covid1.2.0"
       volumes:
          - ${DATA_VOLUME}:/data
          - ${USER_VOLUME}:/home/jovyan/pd


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
covid19

### Description of changes
Switch jupyter image to 1.2.0