### PR TITLE
Fix qa-heal Discovery manifest field name to align with HEAL preprod

### DIFF
--- a/qa-heal.planx-pla.net/portal/gitops.json
+++ b/qa-heal.planx-pla.net/portal/gitops.json
@@ -106,7 +106,7 @@
       },
       "exportToWorkspaceBETA": {
         "enabled": true,
-        "manifestFieldName": "_file_manifest",
+        "manifestFieldName": "__manifest",
         "enableDownloadManifest": false
       },
       "pageTitle": {


### PR DESCRIPTION
### Environments
- qa-heal.planx-pla.net

### Description of changes
 - Fix qa-heal Discovery manifest field name to align with HEAL preprod