### PR TITLE
QAAnVIL_enable_source_node

### DIFF
--- a/qa-anvil.planx-pla.net/portal/gitops.json
+++ b/qa-anvil.planx-pla.net/portal/gitops.json
@@ -213,6 +213,9 @@
           "rightIcon": "download"
         }
       ],
+      "enableLimitedFilePFBExport": {
+        "sourceNodeField": "source_node"
+      },
       "guppyConfig": {
         "dataType": "subject",
         "nodeCountTitle": "Subjects",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments


### Description of changes
Enable the source node for the Data page for AnVIL.