### PR TITLE
changing guppy index type to case in manifest

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -292,7 +292,7 @@
     "indices": [
       {
         "index": "jenkins_subject_alias",
-        "type": "subject"
+        "type": "case"
       },
       {
         "index": "jenkins_file_alias",

--- a/jenkins-brain.planx-pla.net/manifest.json
+++ b/jenkins-brain.planx-pla.net/manifest.json
@@ -289,7 +289,7 @@
     "indices": [
       {
         "index": "jenkins_subject_alias",
-        "type": "subject"
+        "type": "case"
       },
       {
         "index": "jenkins_file_alias",

--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -285,7 +285,7 @@
     "indices": [
       {
         "index": "jenkins_subject_alias",
-        "type": "subject"
+        "type": "case"
       },
       {
         "index": "jenkins_file_alias",

--- a/jenkins-genomel.planx-pla.net/manifest.json
+++ b/jenkins-genomel.planx-pla.net/manifest.json
@@ -293,7 +293,7 @@
     "indices": [
       {
         "index": "jenkins_subject_alias",
-        "type": "subject"
+        "type": "case"
       },
       {
         "index": "jenkins_file_alias",

--- a/jenkins-niaid.planx-pla.net/manifest.json
+++ b/jenkins-niaid.planx-pla.net/manifest.json
@@ -296,7 +296,7 @@
     "indices": [
       {
         "index": "jenkins_subject_alias",
-        "type": "subject"
+        "type": "case"
       },
       {
         "index": "jenkins_file_alias",

--- a/jenkins-perf.planx-pla.net/manifest.json
+++ b/jenkins-perf.planx-pla.net/manifest.json
@@ -74,7 +74,7 @@
     "indices": [
       {
         "index": "jenkins_subject_alias",
-        "type": "subject"
+        "type": "case"
       },
       {
         "index": "jenkins_file_alias",


### PR DESCRIPTION
### Description of changes
Standardize index type to case. Only manifest's guppy block uses type subject which is the type in the special ES index used for guppy tests. 