### PR TITLE
chore (release-update) : Update qa-covid19 to 2021.04 version

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -18,7 +18,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.04",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.04",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.04",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3//data-portal:2021.04",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2021.04",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.04",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.04",

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -26,7 +26,7 @@
     "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.04",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2021.04",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2021.04",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:0.13.0",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.04",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.04",
     "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.2.1",

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -4,34 +4,34 @@
     "That's all I have to say"
   ],
   "versions": {
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.03",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.04",
     "augur": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-augur:fix_docker2",
-    "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2021.03",
+    "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2021.04",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "covid19-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-etl:4.7.3",
     "covid19-notebook-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-notebook-etl:4.7.2",
     "covid19-bayes-model": "quay.io/cdis/covid19-bayes-model:3.4.3",
     "nb-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-nb-etl:4.7.0",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.03",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.03",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.03",
-    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.03",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.03",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.03",
-    "portal": "quay.io/cdis/data-portal:feat_prc-siu-app",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.03",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.04",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.04",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.04",
+    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.04",
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.04",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.04",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3//data-portal:2021.04",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.04",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.03",
+    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.04",
     "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:0.1.5",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.03",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2021.03",
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.04",
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2021.04",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:0.13.0",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.03",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.03",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2021.04",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2021.04",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2021.04",
     "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.2.1",
-    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2021.03",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.03"
+    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2021.04",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2021.04"
   },
   "global": {
     "environment": "qa-covid19",
@@ -64,7 +64,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2021.03"
+      "indexing": "quay.io/cdis/indexs3client:2021.04"
     }
   },
   "sower" : [
@@ -150,7 +150,7 @@
       "serviceAccountName": "jobs-qa-covid19-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/manifest-indexing:2021.03",
+        "image": "quay.io/cdis/manifest-indexing:2021.04",
         "pull_policy": "Always",
         "env": [
           {
@@ -190,7 +190,7 @@
       "serviceAccountName": "jobs-qa-covid19-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/download-indexd-manifest:2021.03",
+        "image": "quay.io/cdis/download-indexd-manifest:2021.04",
         "pull_policy": "Always",
         "env": [
           {
@@ -282,7 +282,7 @@
     "containers": {
       "engine": {
         "name": "mariner-engine",
-        "image": "quay.io/cdis/mariner-engine:2021.03",
+        "image": "quay.io/cdis/mariner-engine:2021.04",
         "pull_policy": "always",
         "command": [
           "/mariner",
@@ -298,7 +298,7 @@
       },
       "s3sidecar": {
         "name": "mariner-s3sidecar",
-        "image": "quay.io/cdis/mariner-s3sidecar:2021.03",
+        "image": "quay.io/cdis/mariner-s3sidecar:2021.04",
         "pull_policy": "always",
         "command": [
           "/sidecar"
@@ -315,7 +315,7 @@
       },
       "gen3fusesidecar": {
         "name": "mariner-gen3fusesidecar",
-        "image": "quay.io/cdis/gen3fuse-sidecar:2021.03",
+        "image": "quay.io/cdis/gen3fuse-sidecar:2021.04",
         "pull_policy": "always",
         "command": [
           "/bin/bash",

--- a/qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-covid19.planx-pla.net/manifests/hatchery/hatchery.json
@@ -5,7 +5,7 @@
   "sidecar": {
     "cpu-limit": "1.0",
     "memory-limit": "256Mi",
-    "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3fuse-sidecar:2021.03",
+    "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3fuse-sidecar:2021.04",
     "env": {
       "NAMESPACE": "qa-covid19",
       "HOSTNAME": "qa-covid19.planx-pla.net"


### PR DESCRIPTION
Releasing `2021.04` to qa-covid19 version
