### PR TITLE
chore: add RENEW_ACCESS_TOKEN_BEFORE_EXPIRATION to public-fence

### DIFF
--- a/qa-covid19.planx-pla.net/manifests/fence/fence-config-public.yaml
+++ b/qa-covid19.planx-pla.net/manifests/fence/fence-config-public.yaml
@@ -212,6 +212,9 @@ MAX_ACCESS_TOKEN_TTL: 3600
 # auth checks against Arborist, and no longer check the token.
 TOKEN_PROJECTS_CUTOFF: 15
 
+# If set to true, will generate an new access token each time when a browser session update happens
+RENEW_ACCESS_TOKEN_BEFORE_EXPIRATION: true
+
 # //////////////////////////////////////////////////////////////////////////////////////
 # SHIBBOLETH
 #   - Support using `shibboleth` in LOGIN_OPTIONS


### PR DESCRIPTION
Adding field `RENEW_ACCESS_TOKEN_BEFORE_EXPIRATION: true` to the `fence-config-public.yaml` file
