### PR TITLE
Revert "(COV-843): chore/update_covid19-portal: update covid19 data-portal image to 2.54.0"

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -18,7 +18,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.04",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.04",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.04",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2.54.0",
+    "portal": "quay.io/cdis/data-portal:feat_prc-siu-app",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:0.5.0",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.04",


### PR DESCRIPTION
Reverts uc-cdis/gitops-qa#1424

Points data portal back to SIU Test branch that has been updated with master 