### PR TITLE
HEAL_qa-Update gitops.json

### DIFF
--- a/qa-heal.planx-pla.net/portal/gitops.json
+++ b/qa-heal.planx-pla.net/portal/gitops.json
@@ -166,14 +166,6 @@
       {
         "name": "Investigator(s)",
         "field": "investigators"
-      },
-      {
-        "name": "Administering IC(s)",
-        "field": "administering_ic"
-      },
-      {
-        "name": "Institution(s)",
-        "field": "institutions"
       }
     ],
     "studyPreviewField": {
@@ -228,6 +220,10 @@
             {
               "name": "Investigator(s)",
               "field": "investigators"
+            },
+            {
+              "name": "Administering IC(s)",
+              "field": "administering_ic"
             },
             {
               "name": "Year Grant Awarded",


### PR DESCRIPTION
Alessandro at 5:33 PM: Btw, can we remove Administering IC and Institution(s) from the front page, and leave them as fields in the study pages?

Link to Jira ticket if there is one: none

### Environments
QA HEAL

### Description of changes
Alessandro at 5:33 PM: Btw, can we remove Administering IC and Institution(s) from the front page, and leave them as fields in the study pages?