### PR TITLE
downgrade audit service

### DIFF
--- a/qa-heal.planx-pla.net/manifest.json
+++ b/qa-heal.planx-pla.net/manifest.json
@@ -8,7 +8,7 @@
   },
   "versions": {
     "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.06",
-    "audit-service": "quay.io/cdis/audit-service:1.0.0",
+    "audit-service": "quay.io/cdis/audit-service:0.1.0",
     "aws-es-proxy": "abutaha/aws-es-proxy:0.8",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.06",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.10.2-debian-cloudwatch-1.0",


### PR DESCRIPTION
Audit service 1.0.0 does not play well with fence:2021.06, so downgrading it to 0.1.0