### PR TITLE
chore(jink): Make "netpolicy" == "on" for hatchery

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -43,7 +43,7 @@
     "logs_bucket": "logs-qaplanetv2-gen3",
     "sync_from_dbgap": "False",
     "dispatcher_job_num": "10",
-    "netpolicy": "off",
+    "netpolicy": "on",
     "public_datasets": true,
     "tier_access_level": "regular",
     "tier_access_limit": "2",

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -336,6 +336,7 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "10",
     "public_datasets": true,
+    "netpolicy":"on",
     "tier_access_level": "regular",
     "tier_access_limit": 50
   },

--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -57,7 +57,7 @@
     "sync_from_dbgap": "False",
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "10",
-    "netpolicy": "off"
+    "netpolicy": "on"
   },
   "canary": {
     "default": 0

--- a/qa-nde.planx-pla.net/manifest.json
+++ b/qa-nde.planx-pla.net/manifest.json
@@ -43,7 +43,7 @@
       "https://qa-microbiome.planx-pla.net",
       "https://qa-flu.planx-pla.net"
     ],
-    "netpolicy": "on",
+    "netpolicy": "off",
     "cookie_domain": "planx-pla.net",
     "public_datasets": true,
     "tier_access_level": "libre"

--- a/qa-nde.planx-pla.net/manifest.json
+++ b/qa-nde.planx-pla.net/manifest.json
@@ -43,7 +43,7 @@
       "https://qa-microbiome.planx-pla.net",
       "https://qa-flu.planx-pla.net"
     ],
-    "netpolicy": "off",
+    "netpolicy": "on",
     "cookie_domain": "planx-pla.net",
     "public_datasets": true,
     "tier_access_level": "libre"


### PR DESCRIPTION
Link to Jira ticket if there is one: [Related Jira Ticket](https://ctds-planx.atlassian.net/browse/PXP-5653)

- Hatchery service would require "netpolicy" to be turned "on" in the global block of the manifest

### Environments
        gitops-qa/qa-covid19.planx-pla.net/manifest.json
        gitops-qa/qa-dcp.planx-pla.net/manifest.json
        gitops-qa/qa-mickey.planx-pla.net/manifest.json

### Description of changes
- Added/ modified "netpolicy" to "on" in the "global" block of manifest.json 