### PR TITLE
fix: remove TOKEN_PROJECTS_CUTOFF from fence_config_public

### DIFF
--- a/qa-ibd.planx-pla.net/manifests/fence/fence-public-config.yaml
+++ b/qa-ibd.planx-pla.net/manifests/fence/fence-public-config.yaml
@@ -102,11 +102,6 @@ MAX_API_KEY_TTL: 2592000
 # The number of seconds after an access token is issued until it expires.
 MAX_ACCESS_TOKEN_TTL: 3600
 
-# TEMPORARY: The maximum number of projects allowed in token claims.
-# This config var should be removed after sheepdog and peregrine support
-# auth checks against Arborist, and no longer check the token.
-TOKEN_PROJECTS_CUTOFF: 15
-
 # //////////////////////////////////////////////////////////////////////////////////////
 # SHIBBOLETH
 #   - Support using `shibboleth` in LOGIN_OPTIONS


### PR DESCRIPTION
remove `TOKEN_PROJECTS_CUTOFF` from the `fence-config-public.yaml` from IBD QA env
