### PR TITLE
fix(pfb-export): Tweak gitops.json to fix PFB Export test flow on qa-dcp

### DIFF
--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -1,6 +1,6 @@
 {
   "notes": [
-    "This is the qa-dcp environment manifest.",
+    "This is the qa-dcp environment manifest",
     "That's all I have to say"
   ],
   "jenkins": {


### PR DESCRIPTION
Trying to fix this error:
```
Cannot query field "programs_name" on type "SubjectAggregation"
```

Indices created in a previous check:
```
$ gen3 es alias | grep gitops
...
  "1515.gitops-qa.qa-dcp_etl_0" : {
      "1515.gitops-qa.qa-dcp_etl" : { },
...
  "1515.gitops-qa.qa-dcp_file_0" : {
      "1515.gitops-qa.qa-dcp_file" : { },
```

Evidence the `programs_name` field definitely exists:
```
$ gen3 es dump "1515.gitops-qa.qa-dcp_etl_0" | grep programs
Handling connection for 9736
          "programs_name" : "DEV",
          "auth_resource_path" : "/programs/QA/projects/test",
...
$ gen3 es dump 1515.gitops-qa.qa-dcp_file_0 | grep programs
Handling connection for 9284
          "programs_name" : [
          "auth_resource_path" : "/programs/QA/projects/test",
          "programs_name" : [
          "auth_resource_path" : "/programs/QA/projects/test",
          "programs_name" : [
          "auth_resource_path" : "/programs/QA/projects/test",
          "programs_name" : [
in both _etl and _file indices