### PR TITLE
chore(ci): Enable PFB Export test for jenkins-blood

### DIFF
--- a/jenkins-blood.planx-pla.net/etlMapping.yaml
+++ b/jenkins-blood.planx-pla.net/etlMapping.yaml
@@ -1,15 +1,85 @@
 mappings:
-  - name: bloodpac
+  - name: jenkins-blood.planx-pla.net_etl
+    doc_type: study
+    type: aggregator
+    root: study
+    props:
+      - name: project_id
+      - name: submitter_id
+      - name: study_setup
+      - name: study_objective
+      - name: study_design
+      - name: study_description
+      - name: data_description
+      - name: associated_study
+    aggregated_props:
+      - name: _cases_count
+        path: cases
+        fn: count
+      - name: _biospecimens_count
+        path: cases.biospecimens
+        fn: count
+      - name: _samples_count
+        path: cases.biospecimens.samples
+        fn: count
+      - name: _aliquots_count
+        path: cases.biospecimens.samples.aliquots
+        fn: count
+      - name: _analytes_count
+        path: cases.biospecimens.samples.aliquots.analytes
+        fn: count
+      - name: _read_groups_count
+        path: cases.biospecimens.samples.aliquots.analytes.read_groups
+        fn: count
+      - name: _immunoassays_count
+        path: cases.biospecimens.samples.aliquots.analytes.immunoassays
+        fn: count
+      - name: _cell_images_count
+        path: cases.biospecimens.samples.aliquots.analytes.cell_images
+        fn: count
+      - name: _pcr_assays_count
+        path: cases.biospecimens.samples.aliquots.analytes.pcr_assays
+        fn: count
+      - name: _pcr_assay_files_count
+        path: cases.biospecimens.samples.aliquots.analytes.pcr_assays.pcr_assay_files
+        fn: count
+      - name: _mass_cytometry_assays_count
+        path: cases.biospecimens.samples.aliquots.analytes.mass_cytometry_assays
+        fn: count
+      - name: _mass_cytometry_images_count
+        path: cases.biospecimens.samples.aliquots.analytes.mass_cytometry_assays.mass_cytometry_images
+        fn: count
+      - name: _slide_images_count
+        path: cases.biospecimens.samples.aliquots.slide_images
+        fn: count
+      - name: _submitted_aligned_reads_files_count
+        path: cases.biospecimens.samples.aliquots.analytes.read_groups.submitted_aligned_reads_files
+        fn: count
+      - name: _submitted_methylations_count
+        path: cases.biospecimens.samples.aliquots.analytes.submitted_methylation_files
+        fn: count
+      - name: _submitted_somatic_mutations_count
+        path: cases.biospecimens.samples.aliquots.analytes.read_groups.submitted_somatic_mutations
+        fn: count
+      - name: _submitted_unaligned_reads_files_count
+        path: cases.biospecimens.samples.aliquots.analytes.read_groups.submitted_unaligned_reads_files
+        fn: count
+    parent_props:
+      - path: projects[project_code:code,project_name:name,project_investigator_affiliation:investigator_affiliation]
+  - name: bloodpac_case
     doc_type: case
     type: aggregator
     root: case
     props:
-      - name: submitter_id
       - name: project_id
+      - name: submitter_id
+      - name: index_date
+      - name: lost_to_followup
     flatten_props:
       - path: demographics
         props:
           - name: gender
+          - name: days_to_birth
           - name: race
           - name: ethnicity
     aggregated_props:
@@ -25,17 +95,26 @@ mappings:
       - name: _analytes_count
         path: biospecimens.samples.aliquots.analytes
         fn: count
+      - name: _read_groups_count
+        path: biospecimens.samples.aliquots.analytes.read_groups
+        fn: count
+      - name: _immunoassays_count
+        path: biospecimens.samples.aliquots.analytes.immunoassays
+        fn: count
       - name: _cell_images_count
         path: biospecimens.samples.aliquots.analytes.cell_images
+        fn: count
+      - name: _pcr_assays_count
+        path: biospecimens.samples.aliquots.analytes.pcr_assays
+        fn: count
+      - name: _pcr_assay_files_count
+        path: biospecimens.samples.aliquots.analytes.pcr_assays.pcr_assay_files
         fn: count
       - name: _mass_cytometry_assays_count
         path: biospecimens.samples.aliquots.analytes.mass_cytometry_assays
         fn: count
       - name: _mass_cytometry_images_count
         path: biospecimens.samples.aliquots.analytes.mass_cytometry_assays.mass_cytometry_images
-        fn: count
-      - name: _read_groups_count
-        path: biospecimens.samples.aliquots.analytes.read_groups
         fn: count
       - name: _slide_images_count
         path: biospecimens.samples.aliquots.slide_images
@@ -52,3 +131,221 @@ mappings:
       - name: _submitted_unaligned_reads_files_count
         path: biospecimens.samples.aliquots.analytes.read_groups.submitted_unaligned_reads_files
         fn: count
+    joining_props:
+      - index: file
+        join_on: case_id
+        props:
+          - name: data_format
+            src: data_format
+            fn: set
+          - name: data_type
+            src: data_type
+            fn: set
+  - name: bloodpac_biospecimen
+    doc_type: biospecimen
+    type: aggregator
+    root: biospecimen
+    props:
+      - name: project_id
+      - name: submitter_id
+      - name: biospecimen_anatomic_site
+      - name: biospecimen_type
+      - name: blood_tube_type
+      - name: days_to_collection
+      - name: days_to_procurement
+      - name: method_of_procurement
+      - name: procured_or_purchased
+      - name: tissue_type
+      - name: disease_type
+      - name: shipping_temperature
+      - name: tumor_code
+      - name: tumor_morphology
+      - name: days_to_collection_other
+      - name: days_to_procurement_other
+      - name: biospecimen_volume
+      - name: blood_draw_method
+      - name: clinical_site
+      - name: primary_site
+      - name: tumor_descriptor
+      - name: procurement_temperature
+      - name: metastatic_bone
+      - name: metastatic_visceral
+      - name: metastatic_lymph_node
+      - name: biospecimen_weight
+    flatten_props:
+      - path: samples
+        props:
+          - name: composition
+          - name: hours_to_fractionation_lower
+          - name: hours_to_fractionation_upper
+          - name: blood_fractionation_method
+          - name: sample_volume
+          - name: storage_agitation
+          - name: storage_agitation_hours
+        sorted_by: updated_datetime, desc
+  - name: bloodpac_aliquot
+    doc_type: aliquot
+    type: aggregator
+    root: aliquot
+    props:
+      - name: project_id
+      - name: submitter_id
+      - name: aliquot_container
+      - name: clinical_or_contrived
+      - name: preservation_method
+      - name: storage_temperature
+      - name: aliquot_volume
+      - name: methanol_added
+      - name: hours_to_freezer_lower
+      - name: hours_to_freezer_lower_other
+      - name: hours_to_freezer_upper
+      - name: hours_to_freezer_upper_other
+      - name: aliquot_quantity
+      - name: contrivance_method
+    flatten_props:
+      - path: analytes
+        props:
+          - name: analyte_isolation_method
+          - name: analyte_type
+          - name: cell_type
+          - name: cell_identifier
+          - name: frame_identifier
+          - name: run_identifier
+          - name: days_to_assay
+        sorted_by: updated_datetime, desc
+  - name: bloodpac_read_group
+    doc_type: read_group
+    type: aggregator
+    root: read_group
+    props:
+      - name: project_id
+      - name: submitter_id
+      - name: instrument_model
+      - name: is_paired_end
+      - name: library_preparation_kit_name
+      - name: library_preparation_kit_vendor
+      - name: library_preparation_kit_version
+      - name: library_strategy
+      - name: platform
+      - name: read_group_name
+      - name: read_length_lower
+      - name: read_length_upper
+      - name: barcoding_applied
+      - name: target_capture_kit_name
+      - name: library_name
+      - name: library_selection
+      - name: sequencing_center
+      - name: library_strand
+      - name: flow_cell_barcode
+      - name: adapter_sequence
+      - name: library_preparation_kit_catalog_number
+      - name: cycles
+  - name: bloodpac_medical_history
+    doc_type: medical_history
+    type: aggregator
+    root: case
+    props:
+      - name: project_id
+      - name: submitter_id
+    flatten_props:
+      - path: comorbidities
+        props:
+          - name: comorbidity
+          - name: days_to_comorbidity
+        sorted_by: updated_datetime, desc
+      - path: diagnoses
+        props:
+          - name: age_at_diagnosis
+          - name: best_overall_response
+          - name: classification_of_tumor
+          - name: days_to_best_overall_response
+          - name: days_to_diagnosis
+          - name: morphology
+          - name: primary_diagnosis
+          - name: prior_treatment
+          - name: tissue_or_organ_of_origin
+          - name: tumor_grade
+          - name: ajcc_clinical_stage
+          - name: overall_survival
+          - name: progression_free_survival
+          - name: ajcc_pathologic_stage
+          - name: method_of_diagnosis
+          - name: ajcc_pathologic_n
+          - name: ajcc_pathologic_t
+          - name: ajcc_pathologic_m
+        sorted_by: updated_datetime, desc
+      - path: diagnostic_tests
+        props:
+          - name: analyte_name
+          - name: days_to_test
+          - name: test_result
+          - name: test_sample_composition
+          - name: test_type
+          - name: test_units
+          - name: test_value
+        sorted_by: updated_datetime, desc
+      - path: followups
+        props:
+          - name: days_to_followup
+          - name: time_from_alcohol
+          - name: time_from_biopsy
+          - name: time_from_exercise
+          - name: time_from_food
+          - name: time_from_physical_trauma
+          - name: time_from_recreational_drugs
+          - name: time_from_tobacco
+          - name: time_from_treatment
+        sorted_by: updated_datetime, desc
+      - path: treatments
+        props:
+          - name: therapeutic_agents
+          - name: treatment_intent_type
+          - name: treatment_type
+          - name: days_to_treatment_start
+          - name: regimen_or_line_of_therapy
+          - name: days_to_treatment_end
+          - name: treatment_class
+          - name: dosage
+          - name: dosage_units
+        sorted_by: updated_datetime, desc
+  - name: bloodpac_publication
+    doc_type: publication
+    type: aggregator
+    root: publication
+    props:
+      - name: project_id
+      - name: accession_id
+      - name: title
+      - name: abstract
+      - name: authors
+      - name: author_affiliations
+      - name: journal
+      - name: publication_url
+      - name: data_availability_date
+      - name: data_description
+      - name: sponsors
+      - name: study_codes
+      - name: condition
+      - name: study_type
+      - name: websites
+  - name: jenkins-blood.planx-pla.net_file
+    doc_type: file
+    type: collector
+    root: None
+    category: data_file
+    props:
+      - name: submitter_id
+      - name: object_id
+      - name: md5sum
+      - name: file_name
+      - name: file_size
+      - name: data_format
+      - name: data_type
+      - name: data_category
+      - name: state
+    injecting_props:
+      case:
+        props:
+          - name: case_id
+            src: id
+          - name: project_id

--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -271,7 +271,7 @@
     "environment": "qaplanetv1",
     "hostname": "jenkins-blood.planx-pla.net",
     "revproxy_arn": "arn:aws:acm:us-east-1:707767160287:certificate/c676c81c-9546-4e9a-9a72-725dd3912bc8",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bpadictionary/develop/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/bpadictionary/master/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-qaplanetv1-gen3",
     "logs_bucket": "logs-qaplanetv1-gen3",

--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -291,15 +291,15 @@
   "guppy": {
     "indices": [
       {
-        "index": "jenkins_subject_alias",
+        "index": "jenkins-blood.planx-pla.net_etl",
         "type": "subject"
       },
       {
-        "index": "jenkins_file_alias",
+        "index": "jenkins-blood.planx-pla.net_file",
         "type": "file"
       }
     ],
-    "config_index": "jenkins_configs_alias",
+    "config_index": "jenkins-blood.planx-pla.net_array-config",
     "auth_filter_field": "auth_resource_path"
   },
   "scaling": {

--- a/jenkins-blood.planx-pla.net/portal/gitops.css
+++ b/jenkins-blood.planx-pla.net/portal/gitops.css
@@ -1,1 +1,9 @@
-/* gitops default css */
+/* Discovery page specs */
+.discovery-header__stat-number {
+    font-size: 40px;
+    line-height: 50px;
+}
+
+.ant-table-thead {
+  font-weight: 900;
+}

--- a/jenkins-blood.planx-pla.net/portal/gitops.json
+++ b/jenkins-blood.planx-pla.net/portal/gitops.json
@@ -392,7 +392,14 @@
           "title": "Export to Workspace",
           "leftIcon": "datafile",
           "rightIcon": "download"
-        }
+        },
+        {
+          "enabled": true,
+          "type": "export-to-pfb",
+          "title": "Export to PFB",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        } 
       ],
       "guppyConfig": {
         "dataType": "case",

--- a/jenkins-blood.planx-pla.net/portal/gitops.json
+++ b/jenkins-blood.planx-pla.net/portal/gitops.json
@@ -1,16 +1,15 @@
 {
   "gaTrackingId": "UA-119127212-2",
   "graphql": {
-    "boardCounts": [
+    "boardCounts": [{
+        "graphql": "_study_count",
+        "name": "Study",
+        "plural": "Studies"
+      },
       {
         "graphql": "_case_count",
         "name": "Case",
         "plural": "Cases"
-      },
-      {
-        "graphql": "_study_count",
-        "name": "Study",
-        "plural": "Studies"
       },
       {
         "graphql": "_aliquot_count",
@@ -18,17 +17,53 @@
         "plural": "Aliquots"
       }
     ],
-    "chartCounts": [
-      {
-        "graphql": "_case_count",
-        "name": "Case"
+    "chartCounts": [{
+        "graphql": "_study_count",
+        "name": "Study",
+        "plural": "Studies"
       },
       {
-        "graphql": "_study_count",
-        "name": "Study"
+        "graphql": "_case_count",
+        "name": "Case",
+        "plural": "Cases"
+      },
+      {
+        "graphql": "_aliquot_count",
+        "name": "Aliquot",
+        "plural": "Aliquots"
       }
     ],
     "projectDetails": "boardCounts"
+  },
+  "useArboristUI": true,
+  "showArboristAuthzOnProfile": true,
+  "showFenceAuthzOnProfile": false,
+  "componentToResourceMapping": {
+    "Workspace": {
+      "resource": "/workspace",
+      "method": "access",
+      "service": "jupyterhub"
+    },
+    "Query": {
+      "resource": "/query_page",
+      "method": "access",
+      "service": "query_page"
+    },
+    "Send Queries": {
+      "resource": "/query_page",
+      "method": "access",
+      "service": "query_page"
+    },
+    "Data Dictionary": {
+      "resource": "/dictionary_page",
+      "method": "access",
+      "service": "dictionary_page"
+    },
+    "Dictionary": {
+      "resource": "/dictionary_page",
+      "method": "access",
+      "service": "dictionary_page"
+    }
   },
   "components": {
     "appName": "BloodPAC Metadata Submission Portal",
@@ -38,45 +73,56 @@
         "text": "The Blood Profiling Atlas in Cancer (BloodPAC) supports the management, analysis and sharing of liquid biopsy data for the oncology research community and aims to accelerate discovery and development of therapies, diagnostic tests, and other technologies for cancer treatment and prevention. The data commons supports cross-project analyses by harmonizing data from different projects through the collaborative development of a data dictionary, providing an API for data queries and download, and providing a cloud-based analysis workspace with rich tools and resources.",
         "link": "/submission"
       },
-      "buttons": [
+      "homepageChartNodes": [{
+          "node": "study",
+          "name": "Studies"
+        },
         {
-          "name": "Define Data Field",
+          "node": "case",
+          "name": "Cases"
+        },
+        {
+          "node": "aliquot",
+          "name": "Aliquots"
+        }
+      ],
+      "buttons": [{
+          "name": "Data Dictionary",
           "icon": "data-field-define",
-          "body": "The BloodPAC Data Commons define the data in a general way. Please study the dictionary before you start browsing.",
+          "body": "The BloodPAC Data Commons employs a data model to power queries and data submissions. Study the dictionary to send GraphQL queries or format your data submissions.",
           "link": "/DD",
           "label": "Learn more"
         },
         {
           "name": "Submit Data",
           "icon": "data-submit",
-          "body": "Submit Data based on the dictionary.",
+          "body": "Browse the list of submitted data projects, or find your project and submit data.",
           "link": "/submission",
           "label": "Submit data"
         },
         {
           "name": "Explore Data",
           "icon": "data-files",
-          "body": "The Explorer page gives you insights and a clear overview of data.",
+          "body": "The Exploration app enables faceted search for cohort building, getting file download manifests, and browsing data across projects.",
           "link": "/explorer",
-          "label": "Explore data"
+          "label": "Exploration"
         },
         {
-          "name": "Access Data",
+          "name": "Send Queries",
           "icon": "data-access",
-          "body": "Getting metadata and other clinical variables exposed by API in our secure cloud environment.",
+          "body": "Build and send your own custom GraphQL queries to the database to pinpoint specific data.",
           "link": "/query",
-          "label": "Query data"
+          "label": "Send Queries"
         }
       ]
     },
     "navigation": {
       "title": "BloodPAC Data Commons",
-      "items": [
-        {
-          "icon": "dictionary",
-          "link": "/DD",
+      "items": [{
+          "icon": "query",
+          "link": "/discovery",
           "color": "#a2a2a2",
-          "name": "Dictionary"
+          "name": "Discovery"
         },
         {
           "icon": "exploration",
@@ -85,16 +131,22 @@
           "name": "Exploration"
         },
         {
-          "icon": "query",
-          "link": "/query",
-          "color": "#a2a2a2",
-          "name": "Query"
-        },
-        {
           "icon": "workspace",
           "link": "/workspace",
           "color": "#a2a2a2",
           "name": "Workspace"
+        },
+        {
+          "icon": "dictionary",
+          "link": "/DD",
+          "color": "#a2a2a2",
+          "name": "Dictionary"
+        },
+        {
+          "icon": "query",
+          "link": "/query",
+          "color": "#a2a2a2",
+          "name": "Query"
         },
         {
           "icon": "profile",
@@ -105,7 +157,10 @@
       ]
     },
     "topBar": {
-      "items": [
+      "items": [{
+          "link": "https://bloodpac.org/",
+          "name": "About"
+        },
         {
           "icon": "upload",
           "link": "/submission",
@@ -114,8 +169,13 @@
         {
           "link": "https://www.synapse.org/#!Synapse:syn8011461/wiki/411591",
           "name": "Documentation"
+        },
+        {
+          "link": "bpa-support@datacommons.io",
+          "name": "Email Support"
         }
-      ]
+      ],
+      "useProfileDropdown": false
     },
     "login": {
       "title": "BloodPAC Data Commons",
@@ -123,303 +183,256 @@
       "text": "This website combines liquid biopsy data from academic, government, and industry partners and aims to accelerate discovery and development of therapies, diagnostic tests, and other technologies for the treatment and prevention of cancer.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "bpa-support@datacommons.io"
+    },
+    "certs": {
+      "security_quiz": {
+        "hasCorrectAnswers": true,
+        "title": "BloodPAC User agreement",
+        "description": "",
+        "questions": [{
+          "name": "",
+          "question": "NOTICE:  To protect the system from unauthorized use and to ensure that the system is functioning, activities on this system are monitored and recorded and subject to audit.  Use of this system is express consent to such monitoring and recording.  Any unauthorized access or use of this system is prohibited.  You may only use this system if you have been designated as an Authenticated Individual by your company or institution.  You may not use the system in any way that is inconsistent with the agreements between CCSR and your company or institution. Please pay particular attention to the restrictions on controlled access data and transfer it in an approved secure manner.",
+          "options": ["I agree"],
+          "answer": 0,
+          "hint": "Click on I agree"
+        }]
+      }
     }
   },
   "featureFlags": {
-    "explorer": true
+    "explorer": true,
+    "analysis": true,
+    "explorerPublic": true,
+    "discovery": true
   },
-  "explorerConfig": [
-      {
-          "tabTitle": "Studies",
-          "charts": {
-            "project_id": {
-              "chartType": "count",
-              "title": "Projects"
-            },
-            "study_setup": {
-              "chartType": "bar",
-              "title": "Study Setup"
-            },
-            "study_objective": {
-              "chartType": "bar",
-              "title": "Study Objective"
-            },
-            "study_design": {
-              "chartType": "bar",
-              "title": "Study Design"
-            }
-          },
-          "filters": {
-            "tabs": [
-              {
-                "title": "Studies",
-                "fields":[
-                  "project_id",
-                  "study_setup",
-                  "study_objective",
-                  "study_design"
-                ]
-              }
-            ]
-          },
-          "table": {
-            "enabled": true,
-            "fields": [
-              "project_id",
-              "submitter_id",
-              "study_description",
-              "data_description",
-              "study_setup",
-              "study_objective",
-              "study_design",
-              "associated_study",
-              "_cases_count",
-              "_biospecimens_count",
-              "_samples_count",
-              "_aliquots_count",
-              "_analytes_count",
-              "_immunoassays_count",
-              "_pcr_assays_count",
-              "_pcr_assay_files_count",
-              "_read_groups_count",
-              "_cell_images_count",
-              "_mass_cytometry_assays_count",
-              "_mass_cytometry_images_count",
-              "_slide_images_count",
-              "_submitted_unaligned_reads_files_count",
-              "_submitted_aligned_reads_files_count",
-              "_submitted_somatic_mutations_count",
-              "_submitted_methylations_count"
-            ]
-          },
-          "buttons": [
-            {
-              "enabled": true,
-              "type": "data",
-              "title": "Download Studies",
-              "leftIcon": "user",
-              "rightIcon": "download",
-              "fileName": "studies.json"
-            },
-            {
-              "enabled": false,
-              "type": "manifest",
-              "title": "Download Manifest",
-              "leftIcon": "datafile",
-              "rightIcon": "download",
-              "fileName": "manifest.json"
-            },
-            {
-              "enabled": true,
-              "type": "export-to-workspace",
-              "title": "Export to Workspace",
-              "leftIcon": "datafile",
-              "rightIcon": "download"
-            }
-          ],
-          "arrangerConfig": {
-            "projectId": "search",
-            "graphqlField": "study",
-            "index": "",
-            "nodeCountField": "project_id"
-          },
-          "guppyConfig": {
-            "dataType": "study",
-            "nodeCountTitle": "Studies",
-            "fieldMapping": [],
-            "manifestMapping": {
-              "resourceIndexType": "file",
-              "resourceIdField": "object_id",
-              "referenceIdFieldInResourceIndex": "case_id",
-              "referenceIdFieldInDataIndex": "case_id"
-            },
-            "accessibleFieldCheckList": ["project_id"],
-            "accessibleValidationField": "project_id"
-          }
-    },
-    {
-        "tabTitle": "Cases",
-        "charts": {
-          "project_id": {
-            "chartType": "count",
-            "title": "Projects"
-          },
-          "gender": {
-            "chartType": "pie",
-            "title": "Gender"
-          },
-          "race": {
-            "chartType": "bar",
-            "title": "Race"
-          },
-          "ethnicity": {
-            "chartType": "bar",
-            "title": "Ethnicity"
-          }
+  "analysisTools": [],
+  "explorerConfig": [{
+      "tabTitle": "Studies",
+      "charts": {
+        "project_id": {
+          "chartType": "count",
+          "title": "Projects"
         },
-        "filters": {
-          "tabs": [
-            {
-              "title": "Cases",
-              "fields":[
-                "project_id",
-                "index_date",
-                "lost_to_followup",
-                "gender",
-                "days_to_birth",
-                "race",
-                "ethnicity"
-              ]
-            }
-          ]
+        "study_setup": {
+          "chartType": "bar",
+          "title": "Study Setup"
         },
-        "table": {
-          "enabled": true,
+        "study_objective": {
+          "chartType": "bar",
+          "title": "Study Objective"
+        },
+        "study_design": {
+          "chartType": "bar",
+          "title": "Study Design"
+        }
+      },
+      "filters": {
+        "tabs": [{
+          "title": "Studies",
           "fields": [
             "project_id",
-            "submitter_id",
+            "study_setup",
+            "study_objective",
+            "study_design"
+          ]
+        }]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "submitter_id",
+          "study_description",
+          "data_description",
+          "study_setup",
+          "study_objective",
+          "study_design",
+          "associated_study",
+          "_cases_count",
+          "_biospecimens_count",
+          "_samples_count",
+          "_aliquots_count",
+          "_analytes_count",
+          "_immunoassays_count",
+          "_pcr_assays_count",
+          "_pcr_assay_files_count",
+          "_read_groups_count",
+          "_cell_images_count",
+          "_mass_cytometry_assays_count",
+          "_mass_cytometry_images_count",
+          "_slide_images_count",
+          "_submitted_unaligned_reads_files_count",
+          "_submitted_aligned_reads_files_count",
+          "_submitted_somatic_mutations_count",
+          "_submitted_methylations_count"
+        ]
+      },
+      "buttons": [{
+          "enabled": true,
+          "type": "data",
+          "title": "Download Studies",
+          "leftIcon": "user",
+          "rightIcon": "download",
+          "fileName": "studies.json"
+        },
+        {
+          "enabled": false,
+          "type": "manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "manifest.json"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "study",
+        "nodeCountTitle": "Studies",
+        "fieldMapping": [],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "case_id",
+          "referenceIdFieldInDataIndex": "case_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      }
+    },
+    {
+      "tabTitle": "Cases",
+      "charts": {
+        "project_id": {
+          "chartType": "count",
+          "title": "Projects"
+        },
+        "gender": {
+          "chartType": "pie",
+          "title": "Gender"
+        },
+        "race": {
+          "chartType": "bar",
+          "title": "Race"
+        },
+        "ethnicity": {
+          "chartType": "bar",
+          "title": "Ethnicity"
+        }
+      },
+      "filters": {
+        "tabs": [{
+          "title": "Cases",
+          "fields": [
+            "project_id",
             "index_date",
             "lost_to_followup",
             "gender",
             "days_to_birth",
             "race",
-            "ethnicity",
-            "data_format",
-            "data_type",
-            "_biospecimens_count",
-            "_samples_count",
-            "_aliquots_count",
-            "_analytes_count",
-            "_immunoassays_count",
-            "_pcr_assays_count",
-            "_pcr_assay_files_count",
-            "_read_groups_count",
-            "_cell_images_count",
-            "_mass_cytometry_assays_count",
-            "_mass_cytometry_images_count",
-            "_slide_images_count",
-            "_submitted_unaligned_reads_files_count",
-            "_submitted_aligned_reads_files_count",
-            "_submitted_somatic_mutations_count",
-            "_submitted_methylations_count"
+            "ethnicity"
           ]
+        }]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "submitter_id",
+          "index_date",
+          "lost_to_followup",
+          "gender",
+          "days_to_birth",
+          "race",
+          "ethnicity",
+          "data_format",
+          "data_type",
+          "_biospecimens_count",
+          "_samples_count",
+          "_aliquots_count",
+          "_analytes_count",
+          "_immunoassays_count",
+          "_pcr_assays_count",
+          "_pcr_assay_files_count",
+          "_read_groups_count",
+          "_cell_images_count",
+          "_mass_cytometry_assays_count",
+          "_mass_cytometry_images_count",
+          "_slide_images_count",
+          "_submitted_unaligned_reads_files_count",
+          "_submitted_aligned_reads_files_count",
+          "_submitted_somatic_mutations_count",
+          "_submitted_methylations_count"
+        ]
+      },
+      "buttons": [{
+          "enabled": true,
+          "type": "data-tsv",
+          "title": "Download Case Metadata",
+          "leftIcon": "user",
+          "rightIcon": "download",
+          "fileName": "BloodPAC_cases.tsv"
         },
-        "buttons": [
-          {
-            "enabled": true,
-            "type": "data",
-            "title": "Download Cases",
-            "leftIcon": "user",
-            "rightIcon": "download",
-            "fileName": "cases.json"
-          },
-          {
-            "enabled": false,
-            "type": "manifest",
-            "title": "Download Manifest",
-            "leftIcon": "datafile",
-            "rightIcon": "download",
-            "fileName": "manifest.json"
-          },
-          {
-            "enabled": true,
-            "type": "export-to-workspace",
-            "title": "Export to Workspace",
-            "leftIcon": "datafile",
-            "rightIcon": "download"
-          }
-        ],
-        "arrangerConfig": {
-          "projectId": "search",
-          "graphqlField": "case",
-          "index": "",
-          "nodeCountField": "project_id"
+        {
+          "enabled": false,
+          "type": "manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "manifest.json"
         },
-        "guppyConfig": {
-          "dataType": "case",
-          "nodeCountTitle": "Cases",
-          "fieldMapping": [],
-          "manifestMapping": {
-            "resourceIndexType": "file",
-            "resourceIdField": "object_id",
-            "referenceIdFieldInResourceIndex": "case_id",
-            "referenceIdFieldInDataIndex": "case_id"
-          },
-          "accessibleFieldCheckList": ["project_id"],
-          "accessibleValidationField": "project_id"
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "case",
+        "nodeCountTitle": "Cases",
+        "fieldMapping": [],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "case_id",
+          "referenceIdFieldInDataIndex": "case_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      }
+    },
+    {
+      "tabTitle": "Biospecimens",
+      "charts": {
+        "project_id": {
+          "chartType": "count",
+          "title": "Projects"
+        },
+        "biospecimen_anatomic_site": {
+          "chartType": "bar",
+          "title": "Anatomic Site"
+        },
+        "biospecimen_type": {
+          "chartType": "pie",
+          "title": "Biospecimen Type"
+        },
+        "blood_tube_type": {
+          "chartType": "bar",
+          "title": "Blood Tube Type"
         }
       },
-      {
-          "tabTitle": "Biospecimens",
-          "charts": {
-            "project_id": {
-              "chartType": "count",
-              "title": "Projects"
-            },
-            "biospecimen_anatomic_site": {
-              "chartType": "bar",
-              "title": "Anatomic Site"
-            },
-            "biospecimen_type": {
-              "chartType": "pie",
-              "title": "Biospecimen Type"
-            },
-            "blood_tube_type": {
-              "chartType": "bar",
-              "title": "Blood Tube Type"
-            }
-          },
-          "filters": {
-            "tabs": [
-              {
-                "title": "Biospecimens",
-                "fields":[
-                  "project_id",
-                  "biospecimen_anatomic_site",
-                  "biospecimen_type",
-                  "blood_tube_type",
-                  "days_to_collection",
-                  "days_to_procurement",
-                  "method_of_procurement",
-                  "procured_or_purchased",
-                  "tissue_type",
-                  "disease_type",
-                  "shipping_temperature",
-                  "tumor_code",
-                  "tumor_morphology",
-                  "days_to_collection_other",
-                  "days_to_procurement_other",
-                  "biospecimen_volume",
-                  "blood_draw_method",
-                  "clinical_site",
-                  "primary_site",
-                  "tumor_descriptor",
-                  "procurement_temperature",
-                  "metastatic_bone",
-                  "metastatic_visceral",
-                  "metastatic_lymph_node",
-                  "biospecimen_weight"
-                ]
-              },
-              {
-                "title": "Samples",
-                "fields":[
-                  "composition",
-                  "hours_to_fractionation_lower",
-                  "hours_to_fractionation_upper",
-                  "blood_fractionation_method",
-                  "sample_volume",
-                  "storage_agitation",
-                  "storage_agitation_hours"
-                ]
-              }
-            ]
-          },
-          "table": {
-            "enabled": true,
+      "filters": {
+        "tabs": [{
+            "title": "Biospecimens",
             "fields": [
               "project_id",
-              "submitter_id",
               "biospecimen_anatomic_site",
               "biospecimen_type",
               "blood_tube_type",
@@ -443,7 +456,12 @@
               "metastatic_bone",
               "metastatic_visceral",
               "metastatic_lymph_node",
-              "biospecimen_weight",
+              "biospecimen_weight"
+            ]
+          },
+          {
+            "title": "Samples",
+            "fields": [
               "composition",
               "hours_to_fractionation_lower",
               "hours_to_fractionation_upper",
@@ -452,560 +470,707 @@
               "storage_agitation",
               "storage_agitation_hours"
             ]
-          },
-          "buttons": [
-            {
-              "enabled": true,
-              "type": "data",
-              "title": "Download Biospecimens",
-              "leftIcon": "user",
-              "rightIcon": "download",
-              "fileName": "biospecimens.json"
-            },
-            {
-              "enabled": false,
-              "type": "manifest",
-              "title": "Download Manifest",
-              "leftIcon": "datafile",
-              "rightIcon": "download",
-              "fileName": "manifest.json"
-            },
-            {
-              "enabled": true,
-              "type": "export-to-workspace",
-              "title": "Export to Workspace",
-              "leftIcon": "datafile",
-              "rightIcon": "download"
-            }
-          ],
-          "arrangerConfig": {
-            "projectId": "search",
-            "graphqlField": "biospecimen",
-            "index": "",
-            "nodeCountField": "project_id"
-          },
-          "guppyConfig": {
-            "dataType": "biospecimen",
-            "nodeCountTitle": "Biospecimens",
-            "fieldMapping": [],
-            "manifestMapping": {
-              "resourceIndexType": "file",
-              "resourceIdField": "object_id",
-              "referenceIdFieldInResourceIndex": "case_id",
-              "referenceIdFieldInDataIndex": "case_id"
-            },
-            "accessibleFieldCheckList": ["project_id"],
-            "accessibleValidationField": "project_id"
           }
-        },
-        {
-            "tabTitle": "Aliquots",
-            "charts": {
-              "aliquot_container": {
-                "chartType": "bar",
-                "title": "Aliquot Container"
-              },
-              "clinical_or_contrived": {
-                "chartType": "pie",
-                "title": "Clinical vs. Contrived"
-              },
-              "analyte_type": {
-                "chartType": "bar",
-                "title": "Analyte Type"
-              }
-            },
-            "filters": {
-              "tabs": [
-                {
-                  "title": "Aliquots",
-                  "fields":[
-                    "project_id",
-                    "aliquot_container",
-                    "clinical_or_contrived",
-                    "preservation_method",
-                    "storage_temperature",
-                    "aliquot_volume",
-                    "methanol_added",
-                    "hours_to_freezer_lower",
-                    "hours_to_freezer_lower_other",
-                    "hours_to_freezer_upper",
-                    "hours_to_freezer_upper_other",
-                    "aliquot_quantity",
-                    "contrivance_method"
-                  ]
-                },
-                {
-                  "title": "Analytes",
-                  "fields":[
-                    "analyte_isolation_method",
-                    "analyte_type",
-                    "cell_type",
-                    "cell_identifier",
-                    "frame_identifier",
-                    "run_identifier",
-                    "days_to_assay"
-                  ]
-                }
-              ]
-            },
-            "table": {
-              "enabled": true,
-              "fields": [
-                "project_id",
-                "submitter_id",
-                "aliquot_container",
-                "clinical_or_contrived",
-                "preservation_method",
-                "storage_temperature",
-                "aliquot_volume",
-                "methanol_added",
-                "hours_to_freezer_lower",
-                "hours_to_freezer_lower_other",
-                "hours_to_freezer_upper",
-                "hours_to_freezer_upper_other",
-                "aliquot_quantity",
-                "contrivance_method",
-                "analyte_isolation_method",
-                "analyte_type",
-                "cell_type",
-                "cell_identifier",
-                "frame_identifier",
-                "run_identifier",
-                "days_to_assay"
-              ]
-            },
-            "buttons": [
-              {
-                "enabled": true,
-                "type": "data",
-                "title": "Download Aliquots",
-                "leftIcon": "user",
-                "rightIcon": "download",
-                "fileName": "aliquots.json"
-              },
-              {
-                "enabled": false,
-                "type": "manifest",
-                "title": "Download Manifest",
-                "leftIcon": "datafile",
-                "rightIcon": "download",
-                "fileName": "manifest.json"
-              },
-              {
-                "enabled": true,
-                "type": "export-to-workspace",
-                "title": "Export to Workspace",
-                "leftIcon": "datafile",
-                "rightIcon": "download"
-              }
-            ],
-            "arrangerConfig": {
-              "projectId": "search",
-              "graphqlField": "aliquot",
-              "index": "",
-              "nodeCountField": "project_id"
-            },
-            "guppyConfig": {
-              "dataType": "aliquot",
-              "nodeCountTitle": "Aliquots",
-              "fieldMapping": [],
-              "manifestMapping": {
-                "resourceIndexType": "file",
-                "resourceIdField": "object_id",
-                "referenceIdFieldInResourceIndex": "case_id",
-                "referenceIdFieldInDataIndex": "case_id"
-              },
-              "accessibleFieldCheckList": ["project_id"],
-              "accessibleValidationField": "project_id"
-            }
-        },
-        {
-            "tabTitle": "Read Groups",
-            "charts": {
-              "instrument_model": {
-                "chartType": "bar",
-                "title": "Instrument Model"
-              },
-              "library_preparation_kit_name": {
-                "chartType": "bar",
-                "title": "Library Prep Kit"
-              },
-              "library_strategy": {
-                "chartType": "bar",
-                "title": "Library Strategy"
-              },
-              "platform": {
-                "chartType": "bar",
-                "title": "Platform"
-              }
-            },
-            "filters": {
-              "tabs": [
-                {
-                  "title": "Read Groups",
-                  "fields":[
-                    "project_id",
-                    "instrument_model",
-                    "is_paired_end",
-                    "library_preparation_kit_name",
-                    "library_preparation_kit_vendor",
-                    "library_preparation_kit_version",
-                    "library_strategy",
-                    "platform",
-                    "read_group_name",
-                    "read_length_lower",
-                    "read_length_upper",
-                    "barcoding_applied",
-                    "target_capture_kit_name",
-                    "library_name",
-                    "library_selection",
-                    "sequencing_center",
-                    "library_strand",
-                    "flow_cell_barcode",
-                    "adapter_sequence",
-                    "library_preparation_kit_catalog_number",
-                    "cycles"
-                  ]
-                }
-              ]
-            },
-            "table": {
-              "enabled": true,
-              "fields": [
-                "project_id",
-                "submitter_id",
-                "instrument_model",
-                "is_paired_end",
-                "library_preparation_kit_name",
-                "library_preparation_kit_vendor",
-                "library_preparation_kit_version",
-                "library_strategy",
-                "platform",
-                "read_group_name",
-                "read_length_lower",
-                "read_length_upper",
-                "barcoding_applied",
-                "target_capture_kit_name",
-                "library_name",
-                "library_selection",
-                "sequencing_center",
-                "library_strand",
-                "flow_cell_barcode",
-                "adapter_sequence",
-                "library_preparation_kit_catalog_number",
-                "cycles"
-              ]
-            },
-            "buttons": [
-              {
-                "enabled": true,
-                "type": "data",
-                "title": "Download Read Groups",
-                "leftIcon": "user",
-                "rightIcon": "download",
-                "fileName": "read_groups.json"
-              },
-              {
-                "enabled": false,
-                "type": "manifest",
-                "title": "Download Manifest",
-                "leftIcon": "datafile",
-                "rightIcon": "download",
-                "fileName": "manifest.json"
-              },
-              {
-                "enabled": true,
-                "type": "export-to-workspace",
-                "title": "Export to Workspace",
-                "leftIcon": "datafile",
-                "rightIcon": "download"
-              }
-            ],
-            "arrangerConfig": {
-              "projectId": "search",
-              "graphqlField": "read_group",
-              "index": "",
-              "nodeCountField": "project_id"
-            },
-            "guppyConfig": {
-              "dataType": "read_group",
-              "nodeCountTitle": "Read Groups",
-              "fieldMapping": [],
-              "manifestMapping": {
-                "resourceIndexType": "file",
-                "resourceIdField": "object_id",
-                "referenceIdFieldInResourceIndex": "case_id",
-                "referenceIdFieldInDataIndex": "case_id"
-              },
-              "accessibleFieldCheckList": ["project_id"],
-              "accessibleValidationField": "project_id"
-            }
-        },
-        {
-            "tabTitle": "Medical History",
-            "charts": {
-              "primary_diagnosis": {
-                "chartType": "bar",
-                "title": "Primary Diagnoses"
-              },
-              "comorbidity": {
-                "chartType": "bar",
-                "title": "Comorbidities"
-              },
-              "analyte_name": {
-                "chartType": "bar",
-                "title": "Diagnostic Tests"
-              },
-              "therapeutic_agents": {
-                "chartType": "bar",
-                "title": "Treatments"
-              }
-            },
-            "filters": {
-              "tabs": [
-                {
-                  "title": "Projects",
-                  "fields":[
-                    "project_id"
-                  ]
-                },
-                {
-                  "title": "Comorbidities",
-                  "fields":[
-                    "comorbidity",
-                    "days_to_comorbidity"
-                  ]
-                },
-                {
-                  "title": "Diagnoses",
-                  "fields":[
-                    "age_at_diagnosis",
-                    "best_overall_response",
-                    "classification_of_tumor",
-                    "days_to_best_overall_response",
-                    "days_to_diagnosis",
-                    "morphology",
-                    "primary_diagnosis",
-                    "prior_treatment",
-                    "tissue_or_organ_of_origin",
-                    "tumor_grade",
-                    "ajcc_clinical_stage",
-                    "overall_survival",
-                    "progression_free_survival",
-                    "ajcc_pathologic_stage",
-                    "method_of_diagnosis",
-                    "ajcc_pathologic_n",
-                    "ajcc_pathologic_t",
-                    "ajcc_pathologic_m"
-                  ]
-                },
-                {
-                  "title": "Diagnostic Tests",
-                  "fields":[
-                    "analyte_name",
-                    "days_to_test",
-                    "test_result",
-                    "test_sample_composition",
-                    "test_type",
-                    "test_units",
-                    "test_value"
-                  ]
-                },
-                {
-                  "title": "Followups",
-                  "fields":[
-                    "days_to_followup",
-                    "time_from_alcohol",
-                    "time_from_biopsy",
-                    "time_from_exercise",
-                    "time_from_food",
-                    "time_from_physical_trauma",
-                    "time_from_recreational_drugs",
-                    "time_from_tobacco",
-                    "time_from_treatment"
-                  ]
-                },
-                {
-                  "title": "Treatments",
-                  "fields":[
-                    "therapeutic_agents",
-                    "treatment_intent_type",
-                    "treatment_type",
-                    "days_to_treatment_start",
-                    "regimen_or_line_of_therapy",
-                    "days_to_treatment_end",
-                    "treatment_class",
-                    "dosage",
-                    "dosage_units"
-                  ]
-                }
-              ]
-            },
-            "table": {
-              "enabled": true,
-              "fields": [
-                "project_id",
-                "submitter_id",
-                "comorbidity",
-                "days_to_comorbidity",
-                "age_at_diagnosis",
-                "best_overall_response",
-                "classification_of_tumor",
-                "days_to_best_overall_response",
-                "days_to_diagnosis",
-                "morphology",
-                "primary_diagnosis",
-                "prior_treatment",
-                "tissue_or_organ_of_origin",
-                "tumor_grade",
-                "ajcc_clinical_stage",
-                "overall_survival",
-                "progression_free_survival",
-                "ajcc_pathologic_stage",
-                "method_of_diagnosis",
-                "ajcc_pathologic_n",
-                "ajcc_pathologic_t",
-                "ajcc_pathologic_m",
-                "analyte_name",
-                "days_to_test",
-                "test_result",
-                "test_sample_composition",
-                "test_type",
-                "test_units",
-                "test_value",
-                "days_to_followup",
-                "time_from_alcohol",
-                "time_from_biopsy",
-                "time_from_exercise",
-                "time_from_food",
-                "time_from_physical_trauma",
-                "time_from_recreational_drugs",
-                "time_from_tobacco",
-                "time_from_treatment",
-                "therapeutic_agents",
-                "treatment_intent_type",
-                "treatment_type",
-                "days_to_treatment_start",
-                "regimen_or_line_of_therapy",
-                "days_to_treatment_end",
-                "treatment_class",
-                "dosage",
-                "dosage_units"
-              ]
-            },
-            "buttons": [
-              {
-                "enabled": true,
-                "type": "data",
-                "title": "Download Medical History",
-                "leftIcon": "user",
-                "rightIcon": "download",
-                "fileName": "medical_history.json"
-              },
-              {
-                "enabled": false,
-                "type": "manifest",
-                "title": "Download Manifest",
-                "leftIcon": "datafile",
-                "rightIcon": "download",
-                "fileName": "manifest.json"
-              },
-              {
-                "enabled": true,
-                "type": "export-to-workspace",
-                "title": "Export to Workspace",
-                "leftIcon": "datafile",
-                "rightIcon": "download"
-              }
-            ],
-            "arrangerConfig": {
-              "projectId": "search",
-              "graphqlField": "case",
-              "index": "",
-              "nodeCountField": "project_id"
-            },
-            "guppyConfig": {
-              "dataType": "medical_history",
-              "nodeCountTitle": "Medical History",
-              "fieldMapping": [],
-              "manifestMapping": {
-                "resourceIndexType": "file",
-                "resourceIdField": "object_id",
-                "referenceIdFieldInResourceIndex": "case_id",
-                "referenceIdFieldInDataIndex": "case_id"
-              },
-              "accessibleFieldCheckList": ["project_id"],
-              "accessibleValidationField": "project_id"
-            }
-        },
-      {
-        "tabTitle": "Files",
-        "charts": {
-          "data_type": {
-            "chartType": "stackedBar",
-            "title": "File Type"
-          },
-          "data_format": {
-            "chartType": "stackedBar",
-            "title": "File Format"
-          }
-        },
-        "filters": {
-          "tabs": [
-            {
-              "title": "File",
-              "fields": [
-                "project_id",
-                "data_type",
-                "data_format"
-              ]
-            }
-          ]
-        },
-        "table": {
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "submitter_id",
+          "biospecimen_anatomic_site",
+          "biospecimen_type",
+          "blood_tube_type",
+          "days_to_collection",
+          "days_to_procurement",
+          "method_of_procurement",
+          "procured_or_purchased",
+          "tissue_type",
+          "disease_type",
+          "shipping_temperature",
+          "tumor_code",
+          "tumor_morphology",
+          "days_to_collection_other",
+          "days_to_procurement_other",
+          "biospecimen_volume",
+          "blood_draw_method",
+          "clinical_site",
+          "primary_site",
+          "tumor_descriptor",
+          "procurement_temperature",
+          "metastatic_bone",
+          "metastatic_visceral",
+          "metastatic_lymph_node",
+          "biospecimen_weight",
+          "composition",
+          "hours_to_fractionation_lower",
+          "hours_to_fractionation_upper",
+          "blood_fractionation_method",
+          "sample_volume",
+          "storage_agitation",
+          "storage_agitation_hours"
+        ]
+      },
+      "buttons": [{
           "enabled": true,
+          "type": "data-tsv",
+          "title": "Download Biospecimen Metadata",
+          "leftIcon": "user",
+          "rightIcon": "download",
+          "fileName": "BloodPAC_biospecimens.tsv"
+        },
+        {
+          "enabled": false,
+          "type": "manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "manifest.json"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "biospecimen",
+        "nodeCountTitle": "Biospecimens",
+        "fieldMapping": [],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "case_id",
+          "referenceIdFieldInDataIndex": "case_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      }
+    },
+    {
+      "tabTitle": "Aliquots",
+      "charts": {
+        "aliquot_container": {
+          "chartType": "bar",
+          "title": "Aliquot Container"
+        },
+        "clinical_or_contrived": {
+          "chartType": "pie",
+          "title": "Clinical vs. Contrived"
+        },
+        "analyte_type": {
+          "chartType": "bar",
+          "title": "Analyte Type"
+        }
+      },
+      "filters": {
+        "tabs": [{
+            "title": "Aliquots",
+            "fields": [
+              "project_id",
+              "aliquot_container",
+              "clinical_or_contrived",
+              "preservation_method",
+              "storage_temperature",
+              "aliquot_volume",
+              "methanol_added",
+              "hours_to_freezer_lower",
+              "hours_to_freezer_lower_other",
+              "hours_to_freezer_upper",
+              "hours_to_freezer_upper_other",
+              "aliquot_quantity",
+              "contrivance_method"
+            ]
+          },
+          {
+            "title": "Analytes",
+            "fields": [
+              "analyte_isolation_method",
+              "analyte_type",
+              "cell_type",
+              "cell_identifier",
+              "frame_identifier",
+              "run_identifier",
+              "days_to_assay"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "submitter_id",
+          "aliquot_container",
+          "clinical_or_contrived",
+          "preservation_method",
+          "storage_temperature",
+          "aliquot_volume",
+          "methanol_added",
+          "hours_to_freezer_lower",
+          "hours_to_freezer_lower_other",
+          "hours_to_freezer_upper",
+          "hours_to_freezer_upper_other",
+          "aliquot_quantity",
+          "contrivance_method",
+          "analyte_isolation_method",
+          "analyte_type",
+          "cell_type",
+          "cell_identifier",
+          "frame_identifier",
+          "run_identifier",
+          "days_to_assay"
+        ]
+      },
+      "buttons": [{
+          "enabled": true,
+          "type": "data-tsv",
+          "title": "Download Aliquot Metadata",
+          "leftIcon": "user",
+          "rightIcon": "download",
+          "fileName": "aliquots.tsv"
+        },
+        {
+          "enabled": false,
+          "type": "manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "manifest.json"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "aliquot",
+        "nodeCountTitle": "Aliquots",
+        "fieldMapping": [],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "case_id",
+          "referenceIdFieldInDataIndex": "case_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      }
+    },
+    {
+      "tabTitle": "Read Groups",
+      "charts": {
+        "instrument_model": {
+          "chartType": "bar",
+          "title": "Instrument Model"
+        },
+        "library_preparation_kit_name": {
+          "chartType": "bar",
+          "title": "Library Prep Kit"
+        },
+        "library_strategy": {
+          "chartType": "bar",
+          "title": "Library Strategy"
+        },
+        "platform": {
+          "chartType": "bar",
+          "title": "Platform"
+        }
+      },
+      "filters": {
+        "tabs": [{
+          "title": "Read Groups",
           "fields": [
             "project_id",
-            "file_name",
-            "file_size",
-            "object_id"
+            "instrument_model",
+            "is_paired_end",
+            "library_preparation_kit_name",
+            "library_preparation_kit_vendor",
+            "library_preparation_kit_version",
+            "library_strategy",
+            "platform",
+            "read_group_name",
+            "read_length_lower",
+            "read_length_upper",
+            "barcoding_applied",
+            "target_capture_kit_name",
+            "library_name",
+            "library_selection",
+            "sequencing_center",
+            "library_strand",
+            "flow_cell_barcode",
+            "adapter_sequence",
+            "library_preparation_kit_catalog_number",
+            "cycles"
+          ]
+        }]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "submitter_id",
+          "instrument_model",
+          "is_paired_end",
+          "library_preparation_kit_name",
+          "library_preparation_kit_vendor",
+          "library_preparation_kit_version",
+          "library_strategy",
+          "platform",
+          "read_group_name",
+          "read_length_lower",
+          "read_length_upper",
+          "barcoding_applied",
+          "target_capture_kit_name",
+          "library_name",
+          "library_selection",
+          "sequencing_center",
+          "library_strand",
+          "flow_cell_barcode",
+          "adapter_sequence",
+          "library_preparation_kit_catalog_number",
+          "cycles"
+        ]
+      },
+      "buttons": [{
+          "enabled": true,
+          "type": "data-tsv",
+          "title": "Download Read Group Metadata",
+          "leftIcon": "user",
+          "rightIcon": "download",
+          "fileName": "BloodPAC_read_groups.tsv"
+        },
+        {
+          "enabled": false,
+          "type": "manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "manifest.json"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "read_group",
+        "nodeCountTitle": "Read Groups",
+        "fieldMapping": [],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "case_id",
+          "referenceIdFieldInDataIndex": "case_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      }
+    },
+    {
+      "tabTitle": "Medical History",
+      "charts": {
+        "primary_diagnosis": {
+          "chartType": "bar",
+          "title": "Primary Diagnoses"
+        },
+        "comorbidity": {
+          "chartType": "bar",
+          "title": "Comorbidities"
+        },
+        "analyte_name": {
+          "chartType": "bar",
+          "title": "Diagnostic Tests"
+        },
+        "therapeutic_agents": {
+          "chartType": "bar",
+          "title": "Treatments"
+        }
+      },
+      "filters": {
+        "tabs": [{
+            "title": "Projects",
+            "fields": [
+              "project_id"
+            ]
+          },
+          {
+            "title": "Comorbidities",
+            "fields": [
+              "comorbidity",
+              "days_to_comorbidity"
+            ]
+          },
+          {
+            "title": "Diagnoses",
+            "fields": [
+              "age_at_diagnosis",
+              "best_overall_response",
+              "classification_of_tumor",
+              "days_to_best_overall_response",
+              "days_to_diagnosis",
+              "morphology",
+              "primary_diagnosis",
+              "prior_treatment",
+              "tissue_or_organ_of_origin",
+              "tumor_grade",
+              "ajcc_clinical_stage",
+              "overall_survival",
+              "progression_free_survival",
+              "ajcc_pathologic_stage",
+              "method_of_diagnosis",
+              "ajcc_pathologic_n",
+              "ajcc_pathologic_t",
+              "ajcc_pathologic_m"
+            ]
+          },
+          {
+            "title": "Diagnostic Tests",
+            "fields": [
+              "analyte_name",
+              "days_to_test",
+              "test_result",
+              "test_sample_composition",
+              "test_type",
+              "test_units",
+              "test_value"
+            ]
+          },
+          {
+            "title": "Followups",
+            "fields": [
+              "days_to_followup",
+              "time_from_alcohol",
+              "time_from_biopsy",
+              "time_from_exercise",
+              "time_from_food",
+              "time_from_physical_trauma",
+              "time_from_recreational_drugs",
+              "time_from_tobacco",
+              "time_from_treatment"
+            ]
+          },
+          {
+            "title": "Treatments",
+            "fields": [
+              "therapeutic_agents",
+              "treatment_intent_type",
+              "treatment_type",
+              "days_to_treatment_start",
+              "regimen_or_line_of_therapy",
+              "days_to_treatment_end",
+              "treatment_class",
+              "dosage",
+              "dosage_units"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "submitter_id",
+          "comorbidity",
+          "days_to_comorbidity",
+          "age_at_diagnosis",
+          "best_overall_response",
+          "classification_of_tumor",
+          "days_to_best_overall_response",
+          "days_to_diagnosis",
+          "morphology",
+          "primary_diagnosis",
+          "prior_treatment",
+          "tissue_or_organ_of_origin",
+          "tumor_grade",
+          "ajcc_clinical_stage",
+          "overall_survival",
+          "progression_free_survival",
+          "ajcc_pathologic_stage",
+          "method_of_diagnosis",
+          "ajcc_pathologic_n",
+          "ajcc_pathologic_t",
+          "ajcc_pathologic_m",
+          "analyte_name",
+          "days_to_test",
+          "test_result",
+          "test_sample_composition",
+          "test_type",
+          "test_units",
+          "test_value",
+          "days_to_followup",
+          "time_from_alcohol",
+          "time_from_biopsy",
+          "time_from_exercise",
+          "time_from_food",
+          "time_from_physical_trauma",
+          "time_from_recreational_drugs",
+          "time_from_tobacco",
+          "time_from_treatment",
+          "therapeutic_agents",
+          "treatment_intent_type",
+          "treatment_type",
+          "days_to_treatment_start",
+          "regimen_or_line_of_therapy",
+          "days_to_treatment_end",
+          "treatment_class",
+          "dosage",
+          "dosage_units"
+        ]
+      },
+      "buttons": [{
+          "enabled": true,
+          "type": "data-tsv",
+          "title": "Download Medical History",
+          "leftIcon": "user",
+          "rightIcon": "download",
+          "fileName": "medical_history.tsv"
+        },
+        {
+          "enabled": false,
+          "type": "manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "manifest.json"
+        },
+        {
+          "enabled": true,
+          "type": "export-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "guppyConfig": {
+        "dataType": "medical_history",
+        "nodeCountTitle": "Medical History",
+        "fieldMapping": [],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "case_id",
+          "referenceIdFieldInDataIndex": "case_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      }
+    },
+    {
+      "tabTitle": "Files",
+      "charts": {
+        "data_type": {
+          "chartType": "stackedBar",
+          "title": "File Type"
+        },
+        "data_format": {
+          "chartType": "stackedBar",
+          "title": "File Format"
+        }
+      },
+      "filters": {
+        "tabs": [{
+          "title": "File",
+          "fields": [
+            "project_id",
+            "data_type",
+            "data_format"
+          ]
+        }]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "file_name",
+          "file_size",
+          "object_id"
+        ]
+      },
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [{
+          "field": "object_id",
+          "name": "GUID"
+        }],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "case",
+          "resourceIdField": "case_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
+      "buttons": [{
+          "enabled": true,
+          "type": "file-manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "file-manifest.json",
+          "dropdownId": "download"
+        },
+        {
+          "enabled": true,
+          "type": "export-files-to-workspace",
+          "title": "Export to Workspace",
+          "leftIcon": "datafile",
+          "rightIcon": "download"
+        }
+      ],
+      "dropdowns": {}
+    }
+  ],
+  "discoveryConfig": {
+    "features": {
+      "pageTitle": {
+        "enabled": false,
+        "text": "Publication Discovery"
+      },
+      "search": {
+        "searchBar": {
+          "enabled": true
+        }
+      },
+      "authorization": {
+        "enabled": true
+      }
+    },
+    "aggregations": [{
+      "name": "Publications",
+      "field": "_publication_id",
+      "type": "count"
+    }],
+    "tagSelector": {
+      "title": "Tags by category"
+    },
+    "studyColumns": [{
+      "name": "Title",
+      "field": "title",
+      "contentType": "string",
+      "width": 200
+    },
+    {
+      "name": "Journal",
+      "field": "journal",
+      "contentType": "string"
+    },
+    {
+      "name": "Publication URL",
+      "field": "publication_url",
+      "contentType": "string"
+    },
+    {
+      "name": "Condition",
+      "field": "condition",
+      "contentType": "string"
+    }
+  ],
+    "studyPreviewField": {
+      "name": "Abstract",
+      "field": "abstract",
+      "contentType": "string",
+      "includeName": true,
+      "includeIfNotAvailable": false
+    },
+    "studyPageFields": {
+      "header": {
+        "field": "title"
+      },
+      "downloadLinks": {
+        "field": "data_download_links"
+      },
+      "fieldsToShow": [{
+          "groupName": "Publication Identifiers",
+          "includeName": false,
+          "fields": [{
+              "name": "Authors",
+              "field": "authors",
+              "contentType": "string"
+            },
+            {
+              "name": "Affiliations",
+              "field": "author_affiliations",
+              "contentType": "string"
+            },
+            {
+              "name": "Journal",
+              "field": "journal",
+              "contentType": "string"
+            },
+            {
+              "name": "Publication URL",
+              "field": "publication_url",
+              "contentType": "string"
+            },
+            {
+              "name": "Data Availability Date",
+              "field": "data_availability_date",
+              "contentType": "string"
+            },
+            {
+              "name": "Description of Data Available",
+              "field": "data_description",
+              "contentType": "string"
+            },
+            {
+              "name": "Sponsors/Acknowledgements",
+              "field": "sponsors",
+              "contentType": "string"
+            },
+            {
+              "name": "Study Number/Codes",
+              "field": "study_codes",
+              "contentType": "string"
+            },
+            {
+              "name": "Condition",
+              "field": "condition",
+              "contentType": "string"
+            },
+            {
+              "name": "Study Type",
+              "field": "study_type",
+              "contentType": "string"
+            },
+            {
+              "name": "Websites",
+              "field": "websites",
+              "contentType": "string"
+            }
           ]
         },
-        "guppyConfig": {
-          "dataType": "file",
-          "fieldMapping": [
-            { "field": "object_id", "name": "GUID" }
-          ],
-          "nodeCountTitle": "Files",
-          "manifestMapping": {
-            "resourceIndexType": "case",
-            "resourceIdField": "case_id",
-            "referenceIdFieldInResourceIndex": "object_id",
-            "referenceIdFieldInDataIndex": "object_id"
-          },
-          "accessibleFieldCheckList": ["project_id"],
-          "accessibleValidationField": "project_id",
-          "downloadAccessor": "object_id"
-        },
-        "buttons": [
-          {
-            "enabled": true,
-            "type": "file-manifest",
-            "title": "Download Manifest",
-            "leftIcon": "datafile",
-            "rightIcon": "download",
-            "fileName": "file-manifest.json",
-            "dropdownId": "download"
-          },
-          {
-            "enabled": true,
-            "type": "export-files-to-workspace",
-            "title": "Export to Workspace",
-            "leftIcon": "datafile",
-            "rightIcon": "download"
-          }
-        ],
-        "dropdowns": {}
-      }
-  ]
+        {
+          "fields": [{
+            "name": "Abstract",
+            "field": "abstract",
+            "contentType": "paragraphs",
+            "includeName": false,
+            "includeIfNotAvailable": false
+          }]
+        }
+      ]
+    },
+    "minimalFieldMapping": {
+      "tagsListFieldName": "tags",
+      "authzField": "auth_resource_path",
+      "uid": "_publication_id"
+    },
+    "tagCategories": [{
+      "name": "Condition",
+      "color": "rgba(129, 211, 248, 1)",
+      "display": true
+    }]
+  }
 }

--- a/jenkins-brain.planx-pla.net/portal/gitops.json
+++ b/jenkins-brain.planx-pla.net/portal/gitops.json
@@ -297,6 +297,13 @@
         "title": "Export File Manifest to Workspace",
         "leftIcon": "datafile",
         "rightIcon": "download"
+      },
+      {
+        "enabled": true,
+        "type": "export-to-pfb",
+        "title": "Export to PFB",
+        "leftIcon": "datafile",
+        "rightIcon": "download"
       }
     ]
   },


### PR DESCRIPTION
Setting up exclusive per-jenkins-env ES indices.

1. Take jenkins env out of rotation (quarantine)
2. ssh to jenkins env
3. Make sure there’s no data in sheepdog (if there is.. just run this: https://jenkins.planx-pla.net/job/self-service-gen3-db-reset-sheepdog/)
4. Run `kubectl edit cm etl-mapping` & rename name parameters from *_etl (or *_subject ) and *_file  to jenkins-<name>,planx.pla-net_etl (regardless if it contains _etl or _subject.. we should set it to _etl as per the diagram) & jenkins-<name>,planx.pla-net_file.
5. Run `gen3 job run gentestdata` to populate the sheepdog database with some data
6. Run `gen3 job run etl` wait for the etl pod (running the tube container) to show up and start running, then you can follow the logs with gen3 job logs etl -f (make sure the exit code is zero)
7. Run `kubectl edit cm manifest-guppy` and set the index config to point  index of typesubject to jenkins-<name>,planx.pla-net_etl and the index of type file to jenkins-<name>,planx.pla-net_file  and also set the config_index to jenkins-<name>.planx-pla.net_array-config
8. run `gen3 roll guppy` , wait for the new pod to come up kubectl get pods | grep guppy and then try `https://jenkins-<name>.planx-pla.net/guppy/_status` and make sure the explorer page is coming up properly `https://jenkins-<name>.planx-pla.net/explorer`
9. Create a gitops-qa PR replacing the name params of the etlMapping.yaml and the manifest.json -> guppy config  indices.
(you should also copy the entire portal folder from the corresponding cdis-manifest environment folder that matches that jenkins-env data dictionary, e.g., jenkins-blood -> should use all the artifacts from https://github.com/uc-cdis/cdis-manifest/tree/master/data.bloodpac.org/portal including, of course, its gitops.json).