### PR TITLE
qa-heal remove gen3documentation link

### DIFF
--- a/qa-heal.planx-pla.net/portal/gitops.json
+++ b/qa-heal.planx-pla.net/portal/gitops.json
@@ -55,10 +55,6 @@
     "topBar": {
       "items": [
         {
-          "link": "https://gen3.org/resources/user/",
-          "name": "Gen3 Documentation"
-        },
-        {
           "link": "https://qa-heal.planx-pla.net/dashboard/Public/documentation/index.html",
           "name": "HEAL Documentation"
         }


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
qa-heal

### Description of changes
Remove button of Gen3 Documentation. A general link to Gen3 by CTDS is provided right in the first section of heal docs. Another link to the User Guide of Gen3 will be available in the HEAL documentation under section "downloading data files". 