### PR TITLE
deploy studyViewer to jenkins_blood

### DIFF
--- a/jenkins-blood.planx-pla.net/manifest.json
+++ b/jenkins-blood.planx-pla.net/manifest.json
@@ -278,7 +278,8 @@
     "sync_from_dbgap": "True",
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "5",
-    "netpolicy": "on"
+    "netpolicy": "on",
+    "tier_access_level" : "libre"
   },
   "ssjdispatcher": {
     "job_images": {
@@ -321,6 +322,10 @@
       {
         "index": "jenkins-blood.planx-pla.net_file",
         "type": "file"
+      },
+      {
+        "index": "jenkins_cmc_alias",
+        "type": "clinical_trials"
       }
     ],    
     "config_index": "jenkins-blood.planx-pla.net_array-config",

--- a/jenkins-blood.planx-pla.net/portal/gitops.json
+++ b/jenkins-blood.planx-pla.net/portal/gitops.json
@@ -131,6 +131,12 @@
           "name": "Exploration"
         },
         {
+          "icon": "query",
+          "link": "/study-viewer/clinical_trials",
+          "color": "#a2a2a2",
+          "name": "Study Viewer"
+        },
+        {
           "icon": "workspace",
           "link": "/workspace",
           "color": "#a2a2a2",
@@ -205,6 +211,38 @@
     "explorerPublic": true,
     "discovery": true
   },
+  "studyViewerConfig": [
+    {
+    "dataType": "clinical_trials",
+    "title": "Studies",
+    "titleField": "title",
+    "rowAccessor": "cmc_unique_id",
+    "listItemConfig": {
+      "blockFields": ["brief_summary"],
+      "tableFields": ["data_availability_date", "data_available", "creator", "nct_number", "condition", "category", "clinical_trial_website", "publications"]
+    },
+    "fieldMapping": [
+      { "field": "brief_summary", "name": "Brief Study Description" },
+      { "field": "description", "name": "Detailed Description"},
+      { "field": "creator", "name": "Sponsor"},
+      { "field": "category", "name": "Study Type"},
+      { "field": "clinical_trial_website", "name": "Websites"},
+      { "field": "nct_number", "name": "NCT Number"},
+      { "field": "publications", "name": "Study Publications"}
+    ],
+    "openMode": "close-all",
+    "buttons": [
+      {
+        "type": "download"
+      },
+      {
+        "type": "request_access",
+        "resourceDisplayNameField": "title",
+        "accessRequestedText": "DAR In Progress",
+        "accessRequestedTooltipText": "Your recently submitted DAR is being reviewed by NIAID"
+      }]
+    }
+  ],
   "analysisTools": [],
   "explorerConfig": [{
       "tabTitle": "Studies",


### PR DESCRIPTION
Deploying studyViewer to jenkins-blood

`"useArboristUI" : true` already exists in the gitops.json at 
https://github.com/uc-cdis/gitops-qa/blob/master/jenkins-blood.planx-pla.net/portal/gitops.json#L38