### PR TITLE
chore(dictionary): Bump dicitonary to 1.6.6

### DIFF
--- a/qa-ibd.planx-pla.net/manifest.json
+++ b/qa-ibd.planx-pla.net/manifest.json
@@ -161,7 +161,7 @@
     "environment": "qaplanetv2",
     "hostname": "qa-ibd.planx-pla.net",
     "revproxy_arn": "arn:aws:acm:us-east-1:707767160287:certificate/c676c81c-9546-4e9a-9a72-725dd3912bc8",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ibdgc-dictionary/1.6.4/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ibdgc-dictionary/1.6.5/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-qaplanetv2-gen3",
     "logs_bucket": "logs-qaplanetv2-gen3",

--- a/qa-ibd.planx-pla.net/manifest.json
+++ b/qa-ibd.planx-pla.net/manifest.json
@@ -161,7 +161,7 @@
     "environment": "qaplanetv2",
     "hostname": "qa-ibd.planx-pla.net",
     "revproxy_arn": "arn:aws:acm:us-east-1:707767160287:certificate/c676c81c-9546-4e9a-9a72-725dd3912bc8",
-    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ibdgc-dictionary/1.6.5/schema.json",
+    "dictionary_url": "https://s3.amazonaws.com/dictionary-artifacts/ibdgc-dictionary/1.6.6/schema.json",
     "portal_app": "gitops",
     "kube_bucket": "kube-qaplanetv2-gen3",
     "logs_bucket": "logs-qaplanetv2-gen3",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
qa-ibd


### Description of changes
Updated dictionary version to 1.6.6
