### PR TITLE
PXP-8448 - Register users for download

### DIFF
--- a/qa-midrc.planx-pla.net/portal/gitops.json
+++ b/qa-midrc.planx-pla.net/portal/gitops.json
@@ -307,6 +307,7 @@
               "rightIcon": "download"
             }
           ],
+          "loginForDownload": true,
           "guppyConfig": {
             "dataType": "case",
             "nodeCountTitle": "Cases",
@@ -379,6 +380,7 @@
                 "data_url"
               ]
             },
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "dataset",
               "nodeCountTitle": "Datasets",
@@ -515,6 +517,7 @@
               "rightIcon": "download"
             }
           ],
+          "loginForDownload": true,
           "guppyConfig": {
             "dataType": "virus_data_file",
             "fieldMapping": [
@@ -751,6 +754,7 @@
                 "rightIcon": "download"
               }
             ],
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "imaging_study",
               "nodeCountTitle": "Imaging Studies",
@@ -974,6 +978,7 @@
                 "rightIcon": "download"
               }
             ],
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "radiography_exam",
               "nodeCountTitle": "Digital Radiography Exams",
@@ -1197,6 +1202,7 @@
                 "rightIcon": "download"
               }
             ],
+            "loginForDownload": true,
             "guppyConfig": {
               "dataType": "ct_scan",
               "nodeCountTitle": "CT Scans",


### PR DESCRIPTION


### Environments
This change intended for MIDRC

### Description of changes
This PR adds a configuration variable called 'loginForDownload', when this config is set to 'true' in a commons it redirects users to the login page if they try to download data before logging in. 