### PR TITLE
fixing the pelican export version

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -72,7 +72,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2021.09",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:0.6.2",
         "pull_policy": "Always",
         "env": [
           {


### PR DESCRIPTION
Fixing the pelican-export version to `0.6.2` which has a decoding fix in pypfb, but release version 2021.09 doesnt contain this fix
