### PR TITLE
qa-covid19 portal to 3.17.4

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -17,7 +17,7 @@
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.09",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.09",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.09",
-    "portal": "quay.io/cdis/data-portal:master",
+    "portal": "quay.io/cdis/data-portal:3.17.4",
     "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.09",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.2-debian-cloudwatch",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.09",


### PR DESCRIPTION
Link to Jira ticket if there is one: [COV-1078](https://occ-data.atlassian.net/browse/COV-1078)

depends on https://github.com/uc-cdis/covid19-tools/pull/237 and https://github.com/uc-cdis/cloud-automation/pull/1775

### Environments
qa-covid19

### Description of changes
portal to 3.17.4 (https://github.com/uc-cdis/data-portal/pull/946)