### PR TITLE
qa-covid19 charts config: remove "results" typo

### DIFF
--- a/qa-covid19.planx-pla.net/portal/gitops.json
+++ b/qa-covid19.planx-pla.net/portal/gitops.json
@@ -1267,13 +1267,13 @@
             "title": "Cook County Daily New Cases and Forecast",
             "description": "Here we plot daily case counts over time in Cook county, where the red line is reported cases and the grey shaded area depicts the inferred posterior predicted cases. Forecasts (blue shaded area) show how new case numbers would have developed (95% Bayesian credible intervals).",
             "type": "image",
-            "path": "generative_bayes_model/results/17031/cases.svg"
+            "path": "generative_bayes_model/17031/cases.svg"
           },
           {
             "title": "Cook County Estimated Reproduction Rate (Rt)",
             "description": "Here we plot estimated Rt over time in Cook county. We use a generative logic (primary infection, infection delay and onset delay) to explain how an initial pool of infected cases spreads the COVID-19 at each time-point, according to the time-varying reproduction factor. Shaded areas indicate 95% Bayesian credible intervals.",
             "type": "image",
-            "path": "generative_bayes_model/results/17031/rt.svg"
+            "path": "generative_bayes_model/17031/rt.svg"
           },
           {
             "title": "Using 4-phase Logistic Model And Data From Past 180 Days to Obtain Cumulative Cases Forecasts For Future 60 Days in Illinois",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
qa-covid19

### Description of changes
charts config: remove "results" typo