### PR TITLE
chore: removing labeler from gitops-qa

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,0 @@
-jenkins-niaid:
-- any: ['qa-niaid.planx-pla.net/**/*']


### PR DESCRIPTION
As `studyViewer` has been deployed to all the jenkins env, we wouldnt need to run `NIAID` related PRs against `jenkins-niaid` only
