### PR TITLE
Update covid19-bayes version in qa-covid19 manifest

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -10,7 +10,7 @@
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
     "covid19-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-etl:4.10.0",
     "covid19-notebook-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-notebook-etl:4.9.4",
-    "covid19-bayes-model": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-bayes-model:3.4.3",
+    "covid19-bayes": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-bayes:4.11.0",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.09",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.09",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.09",


### PR DESCRIPTION
Link to Jira ticket if there is one: [COV-1065](https://occ-data.atlassian.net/browse/COV-1065)

### Environments
* qa-covid19

### Description of changes
* Replaced `covid19-bayes-model` repo with `covid19-bayes` in qa-covid19