### PR TITLE
chore : adding s3bucket_url to global manifest

### DIFF
--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -47,7 +47,7 @@
     "tier_access_level": "regular",
     "tier_access_limit": "2",
     "useryaml_s3path": "s3://cdis-gen3-users/qa-covid19/user.yaml",
-    "covid19_etl_bucket": "s3://static.planx-pla.net",
+    "covid19_data_bucket": "s3://static.planx-pla.net",
     "maintenance_mode": "off",
     "lb_type": "internal"
   },

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -47,6 +47,7 @@
     "tier_access_level": "regular",
     "tier_access_limit": "2",
     "useryaml_s3path": "s3://cdis-gen3-users/qa-covid19/user.yaml",
+    "covid19_etl_bucket": "s3://static.planx-pla.net",
     "maintenance_mode": "off",
     "lb_type": "internal"
   },


### PR DESCRIPTION
adding `s3BucketURL` to the global manifest for the purpose to run the covid19-notebook-etl job 
