### PR TITLE
chore(ctds-test-env): set uwsgi-timeout to 60s

### DIFF
--- a/ctds-test-env.planx-pla.net/manifest.json
+++ b/ctds-test-env.planx-pla.net/manifest.json
@@ -218,7 +218,8 @@
     "tier_access_level": "regular",
     "tier_access_limit": 50,
     "public_datasets": true,
-    "dd_enabled": true
+    "dd_enabled": true,
+    "uwsgi-timeout": "60"
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
### Environments
- ctds-test-env


### Description of changes
- set `uwsgi-timeout` to 60 seconds
