### PR TITLE
Add hhs footer for kids-first and jcoin

### DIFF
--- a/qa-covid19.planx-pla.net/portal/gitops.json
+++ b/qa-covid19.planx-pla.net/portal/gitops.json
@@ -503,8 +503,8 @@
           { "field": "title",
             "name": "Intervention Name"
           },
-          {  "field": "nct_number",
-             "name": "NCT Number"
+          { "field": "nct_number",
+            "name": "NCT Number"
           },
           {
             "field": "project_date_collected",

--- a/qa-jcoin.planx-pla.net/portal/gitops.json
+++ b/qa-jcoin.planx-pla.net/portal/gitops.json
@@ -135,6 +135,14 @@
       "email": "support@datacommons.io",
       "image": "/../../../../custom/sponsors/gitops-sponsors/bg"
     },
+    "footer": {
+      "links": [
+        {
+          "text": "HHS Responsible Disclosure Form",
+          "href": "https://hhs.responsibledisclosure.com/hc/en-us"
+        }
+      ]
+    },
     "footerLogos": [
       {
         "src": "/src/img/gen3.png",

--- a/qa-kidsfirst.planx-pla.net/portal/gitops.json
+++ b/qa-kidsfirst.planx-pla.net/portal/gitops.json
@@ -91,6 +91,14 @@
       "text": "The Kids First Data Catalog supports the Kids First Data Resource Center by providing a digital object services that allow interoperability between data commons, including authentication and authorization for controlled access data. For more information about the overall Kids First Data Resource Center see https://kidsfirstdrc.org.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@kidsfirstdrc.org"
+    },
+    "footer": {
+      "links": [
+        {
+          "text": "HHS Responsible Disclosure Form",
+          "href": "https://hhs.responsibledisclosure.com/hc/en-us"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Link to Jira ticket if there is one: [PXP-9245](https://ctds-planx.atlassian.net/browse/PXP-9247), [PXP-9247](https://ctds-planx.atlassian.net/browse/PXP-9247)

### Environments
- qa-kidsfirst
- qa-jcoin			

### Description of changes
- Added HHS url in the footer for QA envirnoments of JCOIN and KidsFirst