### PR TITLE
Updating the HHS link qa-jcoin and qa-ibd

### DIFF
--- a/qa-ibd.planx-pla.net/portal/gitops.json
+++ b/qa-ibd.planx-pla.net/portal/gitops.json
@@ -148,6 +148,10 @@
           "src": "/../../../../custom/sponsors/gitops-sponsors/attribution",
           "href": "https://www.niddk.nih.gov",
           "alt": "Funded by the NIDDK"
+        },
+        {
+          "text": "HHS Responsible Disclosure Form",
+          "href": "https://www.hhs.gov/vulnerability-disclosure-policy/index.html"
         }
       ]
     }

--- a/qa-jcoin.planx-pla.net/portal/gitops.json
+++ b/qa-jcoin.planx-pla.net/portal/gitops.json
@@ -139,7 +139,7 @@
       "links": [
         {
           "text": "HHS Responsible Disclosure Form",
-          "href": "https://hhs.responsibledisclosure.com/hc/en-us"
+          "href": "https://www.hhs.gov/vulnerability-disclosure-policy/index.html"
         }
       ]
     },


### PR DESCRIPTION
This PR 

-> fixing the qa-jcoin HHS link 
-> adding HHS link to footer for qa-ibd
