### PR TITLE
PXP-9341 qa-ibd study viewer link updates

### DIFF
--- a/qa-ibd.planx-pla.net/portal/gitops.json
+++ b/qa-ibd.planx-pla.net/portal/gitops.json
@@ -30,15 +30,16 @@
       "introduction": {
         "heading": "NIDDK IBD Genetics Consortium Data Commons",
         "text": "The Inflammatory Bowel Disease Genetics Consortium Data Commons supports the management, analysis, and sharing of genetic data to support the vision and mission of the IBD genetics consortium.",
-        "link": "/submission"
+        "buttonText": "Browse Studies",
+        "link": "/study-viewer/project"
       },
       "buttons": [
         {
-          "name": "Define Data Field",
-          "icon": "data-field-define",
-          "body": "The data are defined in a generic way by the dictionary. Please study the dictionary before you start browsing.",
-          "link": "/DD",
-          "label": "Learn more"
+          "name": "Browse Studies",
+          "icon": "data-files",
+          "body": "The Studies page provides summary and detailed information about studies on the platform.",
+          "link": "/study-viewer/project",
+          "label": "Browse studies"
         },
         {
           "name": "Explore Data",
@@ -77,45 +78,38 @@
       "title": "NIDDK IBD Genetics Consortium Data Commons",
       "items": [
         {
+          "icon": "query",
+          "link": "/study-viewer/project",
+          "name": "Browse Studies"
+        },
+        {
           "icon": "dictionary",
           "link": "/DD",
-          "color": "#a2a2a2",
           "name": "Dictionary"
         },
         {
           "icon": "exploration",
           "link": "/explorer",
-          "color": "#a2a2a2",
           "name": "Exploration"
         },
         {
           "icon": "query",
           "link": "/query",
-          "color": "#a2a2a2",
           "name": "Query"
         },
         {
           "icon": "analysis",
           "link": "/resource-browser",
-          "color": "#a2a2a2",
           "name": "Notebook Browser"
         },
         {
           "icon": "workspace",
           "link": "#hostname#workspace/",
-          "color": "#a2a2a2",
           "name": "Workspace"
-        },
-        {
-          "icon": "query",
-          "link": "/study-viewer/project",
-          "color": "#a2a2a2",
-          "name": "Study Viewer"
         },
         {
           "icon": "profile",
           "link": "/identity",
-          "color": "#a2a2a2",
           "name": "Profile"
         }
       ]
@@ -433,7 +427,7 @@
   "studyViewerConfig": [
     {
       "dataType": "project",
-      "title": "Projects",
+      "title": "Studies",
       "titleField": "title",
       "rowAccessor": "project_id",
       "openMode": "close-all",


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/PXP-9341

### Environments
qa-ibd

### Description of changes
study viewer link updates:
- move the study viewer button to the left of the nav bar
- rename it from “Study Viewer” to “Browse Studies”
- remove the nav bar buttons "color" config since it doesn't do anything
- update the homepage intro button to link to the study viewer (note that the button text update depends on https://github.com/uc-cdis/data-portal/pull/972)
- add a homepage card linking to the study viewer
- change the study viewer page title from "Projects" to "Studies" for consistency