### PR TITLE
chore(ctds-test-env): rm unnecessary uwsgi timeout

### DIFF
--- a/ctds-test-env.planx-pla.net/manifest.json
+++ b/ctds-test-env.planx-pla.net/manifest.json
@@ -8,7 +8,7 @@
   },
   "versions": {
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "arborist": "quay.io/cdis/arborist:3.3.0",
+    "arborist": "quay.io/cdis/arborist:3.4.0",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
     "datareplicate": "quay.io/cdis/dcf-dataservice:2021.11",
     "fence": "quay.io/cdis/fence:feat_passport",

--- a/ctds-test-env.planx-pla.net/manifest.json
+++ b/ctds-test-env.planx-pla.net/manifest.json
@@ -218,8 +218,7 @@
     "tier_access_level": "regular",
     "tier_access_limit": 50,
     "public_datasets": true,
-    "dd_enabled": true,
-    "uwsgi-timeout": "60"
+    "dd_enabled": true
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
Revert of #1789.

### Environments
- ctds-test-env


### Description of changes
- remove unnecessary setting of `"uwsgi-timeout": "60"` in global block