### PR TITLE
Changing documentation link to gen3 client docs

### DIFF
--- a/qa-mickey.planx-pla.net/portal/gitops.json
+++ b/qa-mickey.planx-pla.net/portal/gitops.json
@@ -122,8 +122,8 @@
             "name": "Submit Data"
           },
           {
-            "link": "https://gen3.org/resources/user/",
-            "name": "Documentation"
+            "link": "https://gen3.org/resources/user/gen3-client/",
+            "name": "Gen3 Client tutorial"
           },
           {
             "link": "support@datacommons.io",


### PR DESCRIPTION
Link to Jira ticket if there is one: no ticket 

### Environments

VA QA server

### Description of changes

We wanted a different link to appear on top-right instead of "Documentation". This new link takes user to the gen3 client docs, so they can easily find information on how to extract the GWAS workflow output files.