### PR TITLE
fix(argo): move bucket properties to manifests directory

### DIFF
--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -87,9 +87,5 @@
     ],
     "config_index": "etl_mickey_array-config",
     "auth_filter_field": "auth_resource_path"
-  },
-  "argo": {
-     "bucket": "second-argo-bucket",
-     "internal-s3-bucket": "gen3-argo-707767160287-devplanetv1"
   }
 }

--- a/qa-mickey.planx-pla.net/manifests/argo/argo.json
+++ b/qa-mickey.planx-pla.net/manifests/argo/argo.json
@@ -6,5 +6,7 @@
         "Scott.DuVall@va.gov": "workflow2",
         "Hamid.Saoudian@va.gov": "workflow3",
         "Craig.Teerlink@va.gov": "workflow4"
-    }
+    },
+    "bucket": "second-argo-bucket",
+    "internal-s3-bucket": "gen3-argo-707767160287-devplanetv1"
 }


### PR DESCRIPTION
* Moved the argo bucket config section to the `manifests/argo/argo.json` file
