### PR TITLE
Feat/dev login

### DIFF
--- a/qa-ibd.planx-pla.net/manifest.json
+++ b/qa-ibd.planx-pla.net/manifest.json
@@ -8,7 +8,7 @@
     "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:integration202205",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:integration202205",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:integration202205",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:5.6.0",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:integration202205",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:integration202205",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:integration202205",

--- a/qa-ibd.planx-pla.net/manifests/fence/fence-config-public.yaml
+++ b/qa-ibd.planx-pla.net/manifests/fence/fence-config-public.yaml
@@ -133,6 +133,8 @@ ITRUST_GLOBAL_LOGOUT: 'https://auth.nih.gov/siteminderagent/smlogout.asp?mode=ni
 LOGIN_OPTIONS:
   - name: 'Login from Google'
     idp: google
+  - name: "Dev login - set username in 'dev_login' cookie"
+    idp: mock_login
 
 # Default login provider:
 # - must be configured in LOGIN_OPTIONS and OPENID_CONNECT

--- a/qa-jcoin.planx-pla.net/manifest.json
+++ b/qa-jcoin.planx-pla.net/manifest.json
@@ -8,7 +8,7 @@
     "aws-es-proxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/aws-es-proxy:v1.3.1",
     "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2022.04",
     "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2022.04",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2022.04",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:5.6.0",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2022.04",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2022.04",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2022.04",

--- a/qa-jcoin.planx-pla.net/manifests/fence/fence-config-public.yaml
+++ b/qa-jcoin.planx-pla.net/manifests/fence/fence-config-public.yaml
@@ -136,6 +136,8 @@ ITRUST_GLOBAL_LOGOUT: 'https://auth.nih.gov/siteminderagent/smlogout.asp?mode=ni
 LOGIN_OPTIONS:
   - name: 'Login from Google'
     idp: google
+  - name: "Dev login - set username in 'dev_login' cookie"
+    idp: mock_login
 
 # Default login provider:
 # - must be configured in LOGIN_OPTIONS and OPENID_CONNECT


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
qa-ibd and qa-jcoin

### Description of changes
enable both real google login and a mock login for testing. Fence "secret" `OPENID_CONNECT` section:
```
OPENID_CONNECT:
  mock_login:
    mock: true
    mock_default_user: mocked_user
    client_id: mock_client_id
    client_secret: mock_client_secret
    redirect_url: mock_redirect_url
```