### PR TITLE
change scaling group name for argo

### DIFF
--- a/qa-mickey.planx-pla.net/manifests/argo/argo.json
+++ b/qa-mickey.planx-pla.net/manifests/argo/argo.json
@@ -1,5 +1,5 @@
 {
-    "scaling_groups" : {
+    "qa_scaling_groups" : {
         "zchen138@uchicago.edu": "workflow",
         "aprokh@uchicago.edu": "workflow",
         "kmhernan@uchicago.edu": "workflow",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
qa-mickey

### Description of changes
change argo variable name from scaling_group to qa_scaling_group