### PR TITLE
Add tube back to qa.planx-pla.net

### DIFF
--- a/qa.planx-pla.net/manifest.json
+++ b/qa.planx-pla.net/manifest.json
@@ -23,7 +23,8 @@
     "revproxy": "quay.io/cdis/nginx:2022.03",
     "sheepdog": "quay.io/cdis/sheepdog:2022.03",
     "dashboard": "quay.io/cdis/gen3-statics:2022.03",
-    "metadata": "quay.io/cdis/metadata-service:2022.03"
+    "metadata": "quay.io/cdis/metadata-service:2022.03",
+    "tube": "quay.io/cdis/tube:2202.03"
   },
   "arborist": {
     "deployment_version": "2"

--- a/qa.planx-pla.net/manifest.json
+++ b/qa.planx-pla.net/manifest.json
@@ -24,7 +24,7 @@
     "sheepdog": "quay.io/cdis/sheepdog:2022.03",
     "dashboard": "quay.io/cdis/gen3-statics:2022.03",
     "metadata": "quay.io/cdis/metadata-service:2022.03",
-    "tube": "quay.io/cdis/tube:2202.03"
+    "tube": "quay.io/cdis/tube:2022.03"
   },
   "arborist": {
     "deployment_version": "2"


### PR DESCRIPTION
### Environments
qa.planx-pla.net

### Description of changes
We need the tube image for the cloud-automation tests to complete. They rely on this manifest. 