### PR TITLE
QA-HEAL: bump requestor version to 1.7.1

### DIFF
--- a/qa-heal.planx-pla.net/manifest.json
+++ b/qa-heal.planx-pla.net/manifest.json
@@ -21,7 +21,7 @@
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2022.08",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2022.08",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:3.29.2",
-    "requestor": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/requestor:1.7.0",
+    "requestor": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/requestor:1.7.1",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2022.08",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2022.08",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2022.08",


### PR DESCRIPTION


### Environments


### Description of changes

* Update requestor to 1.7.1 for qa-heal