### PR TITLE
updated HEAL aggregate_config.json

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2022-08-05T21:33:40Z",
+  "generated_at": "2022-08-17T19:49:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5858,571 +5858,571 @@
       {
         "hashed_secret": "d7a9296e1517c85826ab949abaae07442f8f15fc",
         "is_verified": false,
-        "line_number": 95,
+        "line_number": 137,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "3a4a8a3057b65b67edc597200bb046599096a33c",
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 152,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "26f4706f71ffaa7394698257a5f8b5744cad4655",
         "is_verified": false,
-        "line_number": 117,
+        "line_number": 159,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "476735d5922f7bf2ce403a7afb217864ff5cde60",
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 207,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "fbda6414e58f721b8fb83ea02de930f6cd34c8e6",
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 228,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "dde9364282d7afa55a107baa4d4d0ecbf80f4c8f",
         "is_verified": false,
-        "line_number": 193,
+        "line_number": 235,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "40f37fc310c50ae5a615f062ac109eadc14d3168",
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 242,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "97a7db738d958338c7112931706bcbbb8df6bed4",
         "is_verified": false,
-        "line_number": 207,
+        "line_number": 249,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "dcba8bcf616d53d32351a2dad1e2cf2a2f344c52",
         "is_verified": false,
-        "line_number": 214,
+        "line_number": 256,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "a4bc3d9e941ece871119e70b28413b44f62221ff",
         "is_verified": false,
-        "line_number": 221,
+        "line_number": 263,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "64e63d4ae09c385c95ee61b26c72073244f4a750",
         "is_verified": false,
-        "line_number": 228,
+        "line_number": 270,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "aa4ea0acc6434818a29bf8b18d956891f1135d7e",
         "is_verified": false,
-        "line_number": 235,
+        "line_number": 277,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "ab0150c5f6da682059d71fec292f76063603d489",
         "is_verified": false,
-        "line_number": 242,
+        "line_number": 284,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "c43b4347e03f2018f3e59011d0a8413556d9005b",
         "is_verified": false,
-        "line_number": 249,
+        "line_number": 291,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "a63133a51a782d2fc02b5453d9e4b8d97311edf9",
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 573,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "e268aefcb792ce6a57d1133c8fa48095525ea529",
         "is_verified": false,
-        "line_number": 534,
+        "line_number": 576,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "c8c6d6c462b1cf551b73730c34d1e023575a88dc",
         "is_verified": false,
-        "line_number": 541,
+        "line_number": 583,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "42702f9e49552d91607038925ad0fca153756cc9",
         "is_verified": false,
-        "line_number": 548,
+        "line_number": 590,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "1daece92f86cbaa6e9e0a1279a125a393576fd40",
         "is_verified": false,
-        "line_number": 555,
+        "line_number": 597,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "49c19ac2e140df87e67f22f362ba39f783e093b8",
         "is_verified": false,
-        "line_number": 574,
+        "line_number": 616,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "39ef2666d50ef83983d1c4196c6e0fa086cd9144",
         "is_verified": false,
-        "line_number": 577,
+        "line_number": 619,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "17fc3763345b8c2780d429de102fb0e411c9711b",
         "is_verified": false,
-        "line_number": 584,
+        "line_number": 626,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "12cd3610b2685ccc60c2c32b2f198201ce63204b",
         "is_verified": false,
-        "line_number": 591,
+        "line_number": 633,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "d64e3cc4e2e87a699af44fcff567bdff597c0376",
         "is_verified": false,
-        "line_number": 598,
+        "line_number": 640,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "32e35d2f2f45a586529f521d6219eb538d5a0288",
         "is_verified": false,
-        "line_number": 617,
+        "line_number": 659,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "172998ec3620b09f4990636c07537dda11c20676",
         "is_verified": false,
-        "line_number": 620,
+        "line_number": 662,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "30363496823494a724a496240bc3db15f75d2b5e",
         "is_verified": false,
-        "line_number": 627,
+        "line_number": 669,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "5e37fb59991835cc65717844a7435ad64f568b15",
         "is_verified": false,
-        "line_number": 634,
+        "line_number": 676,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "6c3d4066f2f89edd496d51c4b49f515d93b29cda",
         "is_verified": false,
-        "line_number": 641,
+        "line_number": 683,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "de02bb6ecb18736657eb6eb6e0470ba7c485ad78",
         "is_verified": false,
-        "line_number": 660,
+        "line_number": 702,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "a733cb129be3fbe2fe5a5ddd01c19f0234c27342",
         "is_verified": false,
-        "line_number": 663,
+        "line_number": 705,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "b21bd94145db03c88dc273c428415e6369d66feb",
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 712,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "8b54b2b9700f6124004fa67adaaa7d99e3483dd8",
         "is_verified": false,
-        "line_number": 677,
+        "line_number": 719,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "8f2621649c866378946c5fcbc76f6e0369106ed4",
         "is_verified": false,
-        "line_number": 684,
+        "line_number": 726,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "d1737fc3b7ab355408b23e8760c9f1265b65c0eb",
         "is_verified": false,
-        "line_number": 703,
+        "line_number": 745,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "ca9950ca9fcdf27eda36b24eac22213fa474d647",
         "is_verified": false,
-        "line_number": 706,
+        "line_number": 748,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "6b4ceca80e2339590dea5e0287e50a0e29616711",
         "is_verified": false,
-        "line_number": 713,
+        "line_number": 755,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "4a00438621ce6d6b5fe3749b5fe62bada1b7e436",
         "is_verified": false,
-        "line_number": 720,
+        "line_number": 762,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "fa04a9a10bc5915ae04eca4db2b9292d898b37f2",
         "is_verified": false,
-        "line_number": 727,
+        "line_number": 769,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "82e7adbf4e6ca8d24f89e7b6c03727130e2b0cbd",
         "is_verified": false,
-        "line_number": 734,
+        "line_number": 776,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "8b4ed6e209e3dff1fdd4a01c273cfd8607d70c40",
         "is_verified": false,
-        "line_number": 755,
+        "line_number": 797,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "e0de54968873cbcba524cba465b3b9f5463dd41a",
         "is_verified": false,
-        "line_number": 758,
+        "line_number": 800,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "d391fd6e2d79791bcdbfa9df308cc9cf5b551af6",
         "is_verified": false,
-        "line_number": 765,
+        "line_number": 807,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "a6171f48ad9bfbf08ec950fe7b08f15e58ca7fde",
         "is_verified": false,
-        "line_number": 772,
+        "line_number": 814,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "9b68777479917d27b0ed60ef5a881524dd32d76e",
         "is_verified": false,
-        "line_number": 779,
+        "line_number": 821,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "d13a1bd4cc93d48d365bebe3a945d45b2a90c5a9",
         "is_verified": false,
-        "line_number": 798,
+        "line_number": 840,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "3111c9596494082a282733deec5cd35972541343",
         "is_verified": false,
-        "line_number": 801,
+        "line_number": 843,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "c13240f56f84c4a68a9f0765020df1b7dc57b3b4",
         "is_verified": false,
-        "line_number": 808,
+        "line_number": 850,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "f1565b2bf1a1d9a827d196c42b86808d43fd3c5c",
         "is_verified": false,
-        "line_number": 815,
+        "line_number": 857,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "2e3c3459ae07130e7bd32755740431d73dee1bf5",
         "is_verified": false,
-        "line_number": 822,
+        "line_number": 864,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "d856b7d922db2a8f3b995509b18b1df9731a1b01",
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 871,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "68f3e1f89974ee0a254ba5ad8e21f3875507de6f",
         "is_verified": false,
-        "line_number": 850,
+        "line_number": 892,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "a70714f6811ca1984285a274d803d397a854f437",
         "is_verified": false,
-        "line_number": 853,
+        "line_number": 895,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "6fc3b39e677ed0674bb766d511036cb644061b25",
         "is_verified": false,
-        "line_number": 860,
+        "line_number": 902,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "59fd8c3f61f33197f02003e856946037d304692d",
         "is_verified": false,
-        "line_number": 867,
+        "line_number": 909,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "cfc071d4b772406b421d6c11107af0452c7791a3",
         "is_verified": false,
-        "line_number": 874,
+        "line_number": 916,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "6497035d007fbb86db29830a98375a2d07441e26",
         "is_verified": false,
-        "line_number": 893,
+        "line_number": 935,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "60d65b9cd0ae04bf2d25698255f9fe9c97b5a9b3",
         "is_verified": false,
-        "line_number": 896,
+        "line_number": 938,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "36690c5f0476bf03772314800d25b8439bf0bc27",
         "is_verified": false,
-        "line_number": 903,
+        "line_number": 945,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "e6792e08a82410fff9037572786261320ce41799",
         "is_verified": false,
-        "line_number": 910,
+        "line_number": 952,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "4b3732ebb3fde431f4f3754c3e37cfbfd39ebc75",
         "is_verified": false,
-        "line_number": 917,
+        "line_number": 959,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "e301ed844716902def444c1ce6224999da4b5443",
         "is_verified": false,
-        "line_number": 936,
+        "line_number": 978,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "1677089ffb27fe27f8eb47b005d595adb249eaba",
         "is_verified": false,
-        "line_number": 939,
+        "line_number": 981,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "5c4e740e6edcce4b32ba215f376c46ff685f84ba",
         "is_verified": false,
-        "line_number": 946,
+        "line_number": 988,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "e42f676bca01cfa08a9dd66221ba4c1c965f8d4a",
         "is_verified": false,
-        "line_number": 953,
+        "line_number": 995,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "f2b5ccaff2ce715767e90ba4ee942cb49c269e04",
         "is_verified": false,
-        "line_number": 960,
+        "line_number": 1002,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "4829156f57536223a66876c11203f0232f16b0ba",
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 1021,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "f6f71352db31c6a057b4f37e9dda102366e5e2ff",
         "is_verified": false,
-        "line_number": 982,
+        "line_number": 1024,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "df8364d52aabf1d380a99bfb0ef6d6a34de461a6",
         "is_verified": false,
-        "line_number": 989,
+        "line_number": 1031,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "632db2776362cbd194bcecda2f3a011ef09f0e5d",
         "is_verified": false,
-        "line_number": 996,
+        "line_number": 1038,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "2bfc4e00f3a391f240d8cb6702b2daba2ef5fb26",
         "is_verified": false,
-        "line_number": 1003,
+        "line_number": 1045,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "93ef759d083104f19ae77c221f76a7d8a679a710",
         "is_verified": false,
-        "line_number": 1025,
+        "line_number": 1067,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "25988519ec331829f445662006767e0dd0abc130",
         "is_verified": false,
-        "line_number": 1032,
+        "line_number": 1074,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "43b25a71a5cf1293710ba14ba6ab577a1ae35563",
         "is_verified": false,
-        "line_number": 1039,
+        "line_number": 1081,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "f7fddcb97ba38b1ca1979eb1de3088b812bdd834",
         "is_verified": false,
-        "line_number": 1046,
+        "line_number": 1088,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "b11396ee35dd076a7f08a2d02bfcdb9fd2c0b3ee",
         "is_verified": false,
-        "line_number": 1065,
+        "line_number": 1107,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "b364e8eafbf161dc1789e1e099be2c07f7690ecb",
         "is_verified": false,
-        "line_number": 1068,
+        "line_number": 1110,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "0b2a961e1f852d93ee413d2dbcfe2e09637ae92a",
         "is_verified": false,
-        "line_number": 1075,
+        "line_number": 1117,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "9860b5f9b5478bdb72cfeb2a6f40c7eb7106755e",
         "is_verified": false,
-        "line_number": 1082,
+        "line_number": 1124,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "a709cddb975dedf3c0a6931a710937206f734758",
         "is_verified": false,
-        "line_number": 1089,
+        "line_number": 1131,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "f720282990073f87db353f82c9fe11bb5fd17330",
         "is_verified": false,
-        "line_number": 1108,
+        "line_number": 1150,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "cfe6faa430f539de6a804046e9f92f97c5573431",
         "is_verified": false,
-        "line_number": 1111,
+        "line_number": 1153,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "5c0e0176bf11adac3253cca8c4c2fe350f59eb73",
         "is_verified": false,
-        "line_number": 1118,
+        "line_number": 1160,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "79cde8590d0dedc41f2c0f1fdca767f0f5f6b2aa",
         "is_verified": false,
-        "line_number": 1125,
+        "line_number": 1167,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "35358c7055a2a6a8997239918588e01ed6ae1392",
         "is_verified": false,
-        "line_number": 1132,
+        "line_number": 1174,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "5a2cf84d549c25cf8c117adc380e8d501b6c3c82",
         "is_verified": false,
-        "line_number": 1151,
+        "line_number": 1193,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "2ab98077a4a68016d72b75f4d22fef06db6fd605",
         "is_verified": false,
-        "line_number": 1154,
+        "line_number": 1196,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "68463d5b987ed3868e08bd30c3ec5be831b952b7",
         "is_verified": false,
-        "line_number": 1161,
+        "line_number": 1203,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "ef62359609ac68617f0a01a4419a3dbd9af64f5c",
         "is_verified": false,
-        "line_number": 1168,
+        "line_number": 1210,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "963db3117b5c98e3645a9cdd9d77df9e5feb1302",
         "is_verified": false,
-        "line_number": 1175,
+        "line_number": 1217,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "8ed37aa21f5c9f21ade6e4dd2527bfde5c71ff87",
         "is_verified": false,
-        "line_number": 1194,
+        "line_number": 1236,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "e128ecc842f57ce57e883cc0ab67eaac557c520e",
         "is_verified": false,
-        "line_number": 1197,
+        "line_number": 1239,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "3bcefddae71fd94340005f4b81c06ff1644a9643",
         "is_verified": false,
-        "line_number": 1204,
+        "line_number": 1246,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "d4f7da97231deec20a5de30a8f9ec36cda85cf9c",
         "is_verified": false,
-        "line_number": 1211,
+        "line_number": 1253,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "499dd9a0da3623a288ad3c2bb6c08c787a4750f5",
         "is_verified": false,
-        "line_number": 1218,
+        "line_number": 1260,
         "type": "Hex High Entropy String"
       }
     ],

--- a/qa-heal.planx-pla.net/metadata/aggregate_config.json
+++ b/qa-heal.planx-pla.net/metadata/aggregate_config.json
@@ -1,19 +1,61 @@
 {
-    "gen3_commons": {
+    "configuration": {
+        "schema": {
+		"__manifest": {
+			"type": "array",
+			"properties": {
+				"file_name": {
+					"type": "string"
+				},
+				"file_size": {
+					"type": "integer"
+				}
+			}
+		},
+            "commons_url": {},
+	    "tags": {
+		    "type": "array"
+	    },
+	    "study_description_summary": {},
+	    "project_title": {}
+        },
+	"settings" : {
+		"cache_drs" : true
+	}
+    },
+    "adapter_commons": {
         "HEAL": {
             "mds_url": "https://qa-heal.planx-pla.net/",
-            "commons_url": "https://qa-heal.planx-pla.net/"
+            "commons_url": "https://qa-heal.planx-pla.net/",
+            "adapter": "gen3",
+            "keep_original_fields": false,
+            "field_mappings": {
+		"authz": "path:authz",
+		"tags": "path:tags",
+		"study_description_summary": "path:study_description_summary",
+		"manifest": "path:__manifest",
+		"project_title": "path:project_title",
+                "commons_url": "https://qa-heal.planx-pla.net/"
+            }
         },
         "SAMHDA": {
             "mds_url": "https://qa-heal.planx-pla.net/",
             "commons_url": "https://qa-heal.planx-pla.net",
+            "adapter": "gen3",
+            "keep_original_fields": false,
             "select_field": {
                 "field_name": "data_resource",
                 "field_value": "SAMHDA"
+            },
+            "field_mappings": {
+		"authz": "path:authz",
+                "tags": "path:tags",
+                "study_description_summary": "path:study_description_summary",
+                "manifest": "path:__manifest",
+                "project_title": "path:project_title",
+                "commons_url": "https://qa-heal.planx-pla.net/"
             }
-        }
-    },
-    "adapter_commons": {
+        },
         "ICPSR": {
             "mds_url": "https://www.icpsr.umich.edu/icpsrweb/neutral/oai/studies",
             "commons_url": "https://www.icpsr.umich.edu",


### PR DESCRIPTION
Link to Jira ticket if there is one:
https://ctds-planx.atlassian.net/browse/BRH-240

### Environments


### Description of changes
Updated aggMDS config to suit the new format used by BRH. Removed gen3_commons, added HEAL/SAMHDA to adapter_commons, added a schema with fields and types

Tested in qa-heal, here is the log of `populate`:
```
qa-heal@cdistest_dev_admin:~/cdis-manifest/qa-heal.planx-pla.net/metadata$ kubectl exec $(gen3 pod metadata) -- python /src/src/mds/populate.py --config /aggregate_config.json --hostname esproxy-service --port 9200
Defaulted container "metadata" out of: metadata, metadata-db-migrate (init)
[2022-08-17 19:43:43,988][       mds][   INFO] Populating HEAL using adapter: gen3
[2022-08-17 19:43:45,809][       mds][   INFO] Received 43 from HEAL
[2022-08-17 19:43:46,637][       mds][   INFO] Populating SAMHDA using adapter: gen3
[2022-08-17 19:43:48,437][       mds][   INFO] Received 43 from SAMHDA
[2022-08-17 19:43:49,099][       mds][   INFO] Populating ICPSR using adapter: icpsr
[2022-08-17 19:43:55,555][       mds][   INFO] Received 8 from ICPSR
[2022-08-17 19:43:55,751][       mds][   INFO] Populating ClinicalTrials.gov using adapter: clinicaltrials
[2022-08-17 19:43:57,293][       mds][   INFO] Received 25 from ClinicalTrials.gov
[2022-08-17 19:43:57,757][       mds][   INFO] Populating PDAPS using adapter: pdaps
[2022-08-17 19:44:03,539][       mds][   INFO] Received 16 from PDAPS
OK
```
