### PR TITLE
qa-heal: add qa-jcoin back to agg mds config

### DIFF
--- a/qa-heal.planx-pla.net/metadata/aggregate_config.json
+++ b/qa-heal.planx-pla.net/metadata/aggregate_config.json
@@ -4,6 +4,18 @@
             "mds_url": "https://qa-heal.planx-pla.net/",
             "commons_url": "https://qa-heal.planx-pla.net/"
         },
+        "JCOIN": {
+            "mds_url": "https://qa-jcoin.planx-pla.net/",
+            "commons_url" : "qa-jcoin.planx-pla.net",
+            "columns_to_fields": {
+                "short_name": "name",
+                "full_name": "full_name",
+                "_subjects_count" : "_subjects_count",
+                "study_id" : "study_id",
+                "_unique_id" : "study_id",
+                "study_description" : "study_description"
+            }
+        },
         "SAMHDA": {
             "mds_url": "https://qa-heal.planx-pla.net/",
             "commons_url": "https://qa-heal.planx-pla.net",


### PR DESCRIPTION
Link to Jira ticket if there is one:

reverting the change from #2137
@mbkranz said:
> This should be resolved as I changed it back to "data_dictionary": "", from an object

### Environments
qa-heal

### Description of changes
add qa-jcoin back to agg mds config