### PR TITLE
Remove SESSION_TIMEOUT override

### DIFF
--- a/qa-covid19.planx-pla.net/manifests/fence/fence-config-public.yaml
+++ b/qa-covid19.planx-pla.net/manifests/fence/fence-config-public.yaml
@@ -178,9 +178,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/qa-ibd.planx-pla.net/manifests/fence/fence-config-public.yaml
+++ b/qa-ibd.planx-pla.net/manifests/fence/fence-config-public.yaml
@@ -73,9 +73,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/qa-jcoin.planx-pla.net/manifests/fence/fence-config-public.yaml
+++ b/qa-jcoin.planx-pla.net/manifests/fence/fence-config-public.yaml
@@ -71,9 +71,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/qa-kidsfirst.planx-pla.net/manifests/fence/fence-config-public.yaml
+++ b/qa-kidsfirst.planx-pla.net/manifests/fence/fence-config-public.yaml
@@ -55,9 +55,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 

--- a/qa-niaid.planx-pla.net/manifests/fence/fence-config-public.yaml
+++ b/qa-niaid.planx-pla.net/manifests/fence/fence-config-public.yaml
@@ -99,9 +99,6 @@ ACCESS_TOKEN_EXPIRES_IN: 1200
 # The number of seconds after a refresh token is issued until it expires.
 REFRESH_TOKEN_EXPIRES_IN: 2592000
 
-# The number of seconds after which a browser session is considered stale.
-SESSION_TIMEOUT: 1800
-
 # The maximum session lifetime in seconds.
 SESSION_LIFETIME: 28800
 


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
QA niaid, ibd, jcoin, covid19, kidsfirst

### Description of changes
remove SESSION_TIMEOUT fence config override so we fall back on the default