### PR TITLE
add new GWAS app to QA env

### DIFF
--- a/qa-mickey.planx-pla.net/portal/gitops.json
+++ b/qa-mickey.planx-pla.net/portal/gitops.json
@@ -95,7 +95,8 @@
       "image": "/custom/sponsors/gitops-sponsors/atlas-logo.png"
     },
     "GWASUIApp",
-    "GWASResults"
+    "GWASResults",
+    "GWAS++"
   ],
   "explorerConfig": [
     {


### PR DESCRIPTION
Link to Jira ticket if there is one: NA

### Environments
- VA Data Commons QA 

### Description of changes
- Added the new version of the GWAS app


PS: closer to real release, the new app should just replace GWASUIApp and use that name instead of GWAS++