### PR TITLE
ws tutorial lab to nb

### DIFF
--- a/qa-brh.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-brh.planx-pla.net/manifests/hatchery/hatchery.json
@@ -77,7 +77,6 @@
       },
       "args": [
         "--NotebookApp.base_url=/lw-workspace/proxy/",
-        "--NotebookApp.default_url=/lab",
         "--NotebookApp.password=''",
         "--NotebookApp.token=''",
         "--NotebookApp.shutdown_no_activity_timeout=5400",

--- a/qa-heal.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-heal.planx-pla.net/manifests/hatchery/hatchery.json
@@ -133,7 +133,6 @@
       },
       "args": [
         "--NotebookApp.base_url=/lw-workspace/proxy/",
-        "--NotebookApp.default_url=/lab",
         "--NotebookApp.password=''",
         "--NotebookApp.token=''",
         "--NotebookApp.quit_button=False"


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
QA HEAL and QA BRH

### Description of changes
Jupyter lab is no longer working with the newer tutorial ws images. I order to update and test the tutorials, we need to drop down to jupyter notebook for the tutorial ws.