### PR TITLE
Bump up Data-portal to ` 5.6.1` in qa-brh

### DIFF
--- a/qa-brh.planx-pla.net/manifest.json
+++ b/qa-brh.planx-pla.net/manifest.json
@@ -20,7 +20,7 @@
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.04",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.04",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.04",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.5.0",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.6.1",
     "requestor": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/requestor:2023.04",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.04",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.04",


### PR DESCRIPTION
Link to Jira ticket if there is one:  [BRH-493](https://ctds-planx.atlassian.net/browse/BRH-493) & [BRH-494](https://ctds-planx.atlassian.net/browse/BRH-494)

### Environments
* QA-BRH

### Description of changes
* Upgrade data-portal from 5.5.0 to  5.6.1 

[BRH-493]: https://ctds-planx.atlassian.net/browse/BRH-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRH-494]: https://ctds-planx.atlassian.net/browse/BRH-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ