### PR TITLE
Chore: remove GWASResultsV2 from VA QA

### DIFF
--- a/qa-mickey.planx-pla.net/portal/gitops.json
+++ b/qa-mickey.planx-pla.net/portal/gitops.json
@@ -97,8 +97,7 @@
       "image": "/custom/sponsors/gitops-sponsors/atlas-logo.png"
     },
     "GWASUIApp",
-    "GWASResults",
-    "GWASResultsV2"
+    "GWASResults"
   ],
   "showArboristAuthzOnProfile": false,
   "showFenceAuthzOnProfile": false


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- VA QA

### Description of changes
- remove GWASResultsV2 card since app was renamed to GWASResults