### PR TITLE
change mapping of Study Name from name to short_name

### DIFF
--- a/qa-brh.planx-pla.net/portal/gitops.json
+++ b/qa-brh.planx-pla.net/portal/gitops.json
@@ -205,7 +205,7 @@
     "studyColumns": [
       {
         "name": "Study Name",
-        "field": "name",
+        "field": "short_name",
         "errorIfNotAvailable": false,
         "valueIfNotAvailable": "n/a",
         "width": "157px"


### PR DESCRIPTION
Based on Michelle's research, she can only find the field Study Name in this file. It was mapping to `name`. However, it seems like `short_name` is the field that has the data we want to map to. This PR changes the mapping to `short_name` in the hopes that studies from BDC will come over to BRH with their study names (currently, they are just showing "n/a")