### PR TITLE
Fix: add s3 bucket to connectSrcCSPWhitelist for qa-mickey

### DIFF
--- a/qa-mickey.planx-pla.net/portal/gitops.json
+++ b/qa-mickey.planx-pla.net/portal/gitops.json
@@ -100,5 +100,8 @@
     "GWASResults"
   ],
   "showArboristAuthzOnProfile": false,
-  "showFenceAuthzOnProfile": false
+  "showFenceAuthzOnProfile": false,
+  "connectSrcCSPWhitelist": [
+    "https://second-argo-bucket.s3.amazonaws.com"
+  ]
 }


### PR DESCRIPTION
Link to Jira ticket if there is one: [VADC-535](https://ctds-planx.atlassian.net/browse/VADC-535)

### Environments
- VA QA

### Description of changes
- Add s3 bucket to `connectSrcCSPWhitelist` for qa-mickey. This should solve the error `...violates the following Content Security Policy directive...`

[VADC-535]: https://ctds-planx.atlassian.net/browse/VADC-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ