### PR TITLE
Align brief and detailed table displays in qitops.json

### DIFF
--- a/qa-niaid.planx-pla.net/portal/gitops.json
+++ b/qa-niaid.planx-pla.net/portal/gitops.json
@@ -87,7 +87,7 @@
       "rowAccessor": "cmc_unique_id",
       "listItemConfig": {
         "blockFields": ["brief_summary"],
-        "tableFields": ["data_availability_date", "most_recent_update", "previous_versions", "data_available", "creator", "nct_number", "condition", "category", "clinical_trial_website", "publications","study_registration","study_registration_id"],
+        "tableFields": ["data_availability_date", "most_recent_update", "previous_versions", "data_available", "creator", "nct_number", "condition", "category", "study_design_primary_purpose","study_design_allocation", "study_start_date", "study_completion_date",  "clinical_trial_website", "publications","study_registration","study_registration_id"],
         "hideEmptyFields": true
       },
       "singleItemConfig": {


### PR DESCRIPTION
The QA-NIAID study viewer displays a table of metadata for both summary and detailed views.  Currently they do not match, and the NIAID sponsor has asked that they be made to do so.

Link to Jira ticket if there is one:

### Environments
QA

### Description of changes
Gitops.json was updated to align the displayable table fields for the summary study view with the detailed view