### PR TITLE
Feat: update VADC QA to sprint17 results

### DIFF
--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -23,7 +23,7 @@
     "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/ohdsi/webapi:2.13.0",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.06",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.06",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:feat_vadc_sprint16",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:feat_vadc_sprint17",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.06",
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.06",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.06",


### PR DESCRIPTION
Link to Jira ticket if there is one: NA

### Environments
- VA QA env

### Description of changes
- Update VA QA env so that it displays sprint 17 results
