### PR TITLE
testing new ES7 cluster in Jenkins-Blood

### DIFF
--- a/qa-midrc.planx-pla.net/manifest.json
+++ b/qa-midrc.planx-pla.net/manifest.json
@@ -12,10 +12,10 @@
     "dicom-server": "quay.io/cdis/gen3-orthanc:master",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.05",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.05",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:feat_es7",
     "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.05",
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.05",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.05",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:feat_es-7",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.05",
     "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.05",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.05",
@@ -24,7 +24,7 @@
     "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.05",
     "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.05",
     "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.05",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:0.7.5",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:feat_new-es-7",
     "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.05"
   },
   "arborist": {
@@ -86,7 +86,8 @@
     "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.2.1_data_file/schema.json",
     "sync_from_dbgap": "False",
     "frontend_root": "portal",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
We are attempting to move all Jenkins and QA environments to ES7. Jenkins-blood is currently pointing at the new es7 cluster, so we are testing the automated tests in this environment