### PR TITLE
add static notebook to example analysis page

### DIFF
--- a/qa-brh.planx-pla.net/portal/gitops.json
+++ b/qa-brh.planx-pla.net/portal/gitops.json
@@ -476,6 +476,12 @@
         "description": "In this Jupyter notebook, we'll delve into the Framingham dataset, analyzing its contents, performing exploratory data analysis, and leveraging linear and logistic regression.",
         "link": "/dashboard/Public/notebooks/Predicting_Insights_Into_Heart_Health.html",
         "imageUrl": "/dashboard/Public/notebooks/Predicting_Insights_Into_Heart_Health.png"
+      },
+      {
+        "title": "OADC Unsupervised Data Exploration on Cancer Cell Line Encyclopedia (CCLE)",
+        "description": "Principal component analysis (PCA) and t-distributed stochastic neighbor embedding (t-SNE) has become valuable tools for unsupervised data exploration. This notebook explores the application of unsupervised learning on Cancer Cell Line Encyclopedia (CCLE) gene expression profile. All results shown in this notebook are for demonstration purposes and should not be considered scientifically rigorous.",
+        "link": "/dashboard/Public/notebooks/OADC_CCLE_gene_expression_data_analysis.html",
+        "imageUrl": "/dashboard/Public/notebooks/OADC_CCLE_gene_expression_data_analysis.png"
       }
     ]
   },


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
QA BRH

### Description of changes
define the notebook in portal so it shows up on the example analysis page