### PR TITLE
Feat: add arborist_url as global env to VA QA

### DIFF
--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -51,7 +51,8 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "10",
     "netpolicy": "on",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "arborist_url": "http://arborist-service"
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-775

### Environments
- VA QA 

### Description of changes
- New environment variable so that WebAPI can find Arborist