### PR TITLE
Revert "Feat: add arborist_url as global env to VA QA"

### DIFF
--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -51,8 +51,7 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "10",
     "netpolicy": "on",
-    "lb_type": "internal",
-    "arborist_url": "http://arborist-service"
+    "lb_type": "internal"
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-775

Reverts uc-cdis/gitops-qa#2691