### PR TITLE
Remove ES7

### DIFF
--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -278,8 +278,7 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "5",
     "netpolicy": "on",
-    "tier_access_level" : "libre",
-    "es7": true
+    "tier_access_level" : "libre"
   },
   "ssjdispatcher": {
     "job_images": {


### PR DESCRIPTION

### Environments
- jenkins-dcp

### Description of changes
Remove ES7 so monthly releases in commons not ready for ES7 can run. 