### PR TITLE
Updating all qa environments to point to ES7.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -371,21 +371,21 @@
         "filename": "qa-anvil.planx-pla.net/manifest.json",
         "hashed_secret": "0447a636536df0264b2000403fbefd69f603ceb1",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 145
       },
       {
         "type": "Secret Keyword",
         "filename": "qa-anvil.planx-pla.net/manifest.json",
         "hashed_secret": "ca253d1c9dece2da0d6fb24ded7bdb849a475966",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 151
       },
       {
         "type": "Secret Keyword",
         "filename": "qa-anvil.planx-pla.net/manifest.json",
         "hashed_secret": "7120244dce59930b75711144fda4b1f6d78e4865",
         "is_verified": false,
-        "line_number": 255
+        "line_number": 256
       }
     ],
     "qa-bloodpac.planx-pla.net/manifest.json": [
@@ -6869,28 +6869,28 @@
         "filename": "qa-covid19.planx-pla.net/manifest.json",
         "hashed_secret": "0447a636536df0264b2000403fbefd69f603ceb1",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "qa-covid19.planx-pla.net/manifest.json",
         "hashed_secret": "ca253d1c9dece2da0d6fb24ded7bdb849a475966",
         "is_verified": false,
-        "line_number": 135
+        "line_number": 136
       },
       {
         "type": "Secret Keyword",
         "filename": "qa-covid19.planx-pla.net/manifest.json",
         "hashed_secret": "aee98a99696237d70b6854ee4c2d9e42bc696039",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 142
       },
       {
         "type": "Secret Keyword",
         "filename": "qa-covid19.planx-pla.net/manifest.json",
         "hashed_secret": "7120244dce59930b75711144fda4b1f6d78e4865",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 182
       }
     ],
     "qa-dcp.planx-pla.net/manifest.json": [
@@ -6922,7 +6922,7 @@
         "filename": "qa-heal.planx-pla.net/manifest.json",
         "hashed_secret": "ae4a2a671a528744059cd818de9af9e13005563b",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 106
       }
     ],
     "qa-heal.planx-pla.net/metadata/aggregate_config.json": [
@@ -7602,23 +7602,23 @@
         "filename": "qa-niaid.planx-pla.net/manifest.json",
         "hashed_secret": "0447a636536df0264b2000403fbefd69f603ceb1",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": "qa-niaid.planx-pla.net/manifest.json",
         "hashed_secret": "ca253d1c9dece2da0d6fb24ded7bdb849a475966",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 152
       },
       {
         "type": "Secret Keyword",
         "filename": "qa-niaid.planx-pla.net/manifest.json",
         "hashed_secret": "aee98a99696237d70b6854ee4c2d9e42bc696039",
         "is_verified": false,
-        "line_number": 157
+        "line_number": 158
       }
     ]
   },
-  "generated_at": "2023-10-26T17:01:01Z"
+  "generated_at": "2023-11-29T19:53:24Z"
 }

--- a/qa-acct.planx-pla.net/manifest.json
+++ b/qa-acct.planx-pla.net/manifest.json
@@ -8,24 +8,24 @@
   },
   "versions": {
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2021.06",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2021.06",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2021.06",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2021.06",
-    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2021.06",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2021.06",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2021.06",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2021.06",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.12",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
+    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.12",
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.12",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2021.06",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2021.06",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2021.06",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2021.06",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2021.06",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2021.06",
-    "metadata": "quay.io/cdis/metadata-service:2021.06",
-    "dashboard": "quay.io/cdis/gen3-statics:2021.06"
+    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.12",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.12",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.12",
+    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.12",
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.12",
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.12",
+    "metadata": "quay.io/cdis/metadata-service:2023.12",
+    "dashboard": "quay.io/cdis/gen3-statics:2023.12"
   },
   "arborist": {
     "deployment_version": "2"
@@ -48,7 +48,8 @@
     "dispatcher_job_num": "10",
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "netpolicy": "on",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "ssjdispatcher": {
     "job_images": {

--- a/qa-aids.planx-pla.net/manifest.json
+++ b/qa-aids.planx-pla.net/manifest.json
@@ -5,22 +5,22 @@
   ],
   "versions": {
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "arborist": "quay.io/cdis/arborist:2020.08",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.08",
+    "fence": "quay.io/cdis/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "guppy": "quay.io/cdis/guppy:2020.08",
-    "indexd": "quay.io/cdis/indexd:2020.08",
-    "manifestservice": "quay.io/cdis/manifestservice:2020.08",
-    "peregrine": "quay.io/cdis/peregrine:2020.08",
-    "pidgin": "quay.io/cdis/pidgin:2020.08",
-    "portal": "quay.io/cdis/data-portal:2020.08",
-    "revproxy": "quay.io/cdis/nginx:2020.08",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.08",
-    "sower": "quay.io/cdis/sower:2020.08",
-    "spark": "quay.io/cdis/gen3-spark:2020.08",
-    "tube": "quay.io/cdis/tube:2020.08",
-    "dashboard": "quay.io/cdis/gen3-statics:2020.08"
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "indexd": "quay.io/cdis/indexd:2023.12",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "sower": "quay.io/cdis/sower:2023.12",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "dashboard": "quay.io/cdis/gen3-statics:2023.12"
   },
   "global": {
     "dispatcher_job_num": "10",
@@ -47,7 +47,8 @@
     "netpolicy": "off",
     "cookie_domain": "planx-pla.net",
     "des_namespace": "qa-nde",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "arborist": {
     "deployment_version": "2"
@@ -80,7 +81,7 @@
     "name": "pelican-export",
     "container": {
       "name": "job-task",
-      "image": "quay.io/cdis/pelican:2020.08",
+      "image": "quay.io/cdis/pelican:2023.12",
       "pull_policy": "always",
       "env": [],
       "cpu-limit": "1",
@@ -90,7 +91,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2020.08"
+      "indexing": "quay.io/cdis/indexs3client:2023.12"
     }
   },
   "canary": {

--- a/qa-anvil.planx-pla.net/manifest.json
+++ b/qa-anvil.planx-pla.net/manifest.json
@@ -7,27 +7,27 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "access-backend": "quay.io/cdis/access-backend:2021.06",
+    "access-backend": "quay.io/cdis/access-backend:2023.12",
     "ambassador": "quay.io/datawire/ambassador:0.60.3",
-    "arborist": "quay.io/cdis/arborist:2021.06",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2021.06",
+    "fence": "quay.io/cdis/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "guppy": "quay.io/cdis/guppy:2021.06",
-    "hatchery": "quay.io/cdis/hatchery:2021.06",
-    "indexd": "quay.io/cdis/indexd:2021.06",
-    "manifestservice": "quay.io/cdis/manifestservice:2021.06",
-    "metadata": "quay.io/cdis/metadata-service:2021.06",
-    "peregrine": "quay.io/cdis/peregrine:2021.06",
-    "pidgin": "quay.io/cdis/pidgin:2021.06",
-    "portal": "quay.io/cdis/data-portal:2021.06",
-    "revproxy": "quay.io/cdis/nginx:2021.06",
-    "sheepdog": "quay.io/cdis/sheepdog:2021.06",
-    "sower": "quay.io/cdis/sower:2021.06",
-    "spark": "quay.io/cdis/gen3-spark:2021.06",
-    "tube": "quay.io/cdis/tube:2021.06",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2021.06",
-    "wts": "quay.io/cdis/workspace-token-service:2021.06",
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "hatchery": "quay.io/cdis/hatchery:2023.12",
+    "indexd": "quay.io/cdis/indexd:2023.12",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "metadata": "quay.io/cdis/metadata-service:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "sower": "quay.io/cdis/sower:2023.12",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2023.12",
+    "wts": "quay.io/cdis/workspace-token-service:2023.12",
     "dashboard": "quay.io/cdis/gen3-statics:2020.10"
   },
   "global": {
@@ -45,11 +45,12 @@
     "tier_access_level": "regular",
     "tier_access_limit": 50,
     "public_datasets": true,
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2021.06"
+      "indexing": "quay.io/cdis/indexs3client:2023.12"
     }
   },
   "arborist": {
@@ -90,7 +91,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:2021.06",
+        "image": "quay.io/cdis/pelican-export:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -158,7 +159,7 @@
       "action": "export-files",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/pelican-export:2021.06",
+        "image": "quay.io/cdis/pelican-export:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -224,7 +225,7 @@
       "serviceAccountName": "jobs-qa-anvil-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/metadata-manifest-ingestion:2021.06",
+        "image": "quay.io/cdis/metadata-manifest-ingestion:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -264,7 +265,7 @@
       "serviceAccountName": "jobs-qa-anvil-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/get-dbgap-metadata:2021.06",
+        "image": "quay.io/cdis/get-dbgap-metadata:2023.12",
         "pull_policy": "Always",
         "env": [],
         "volumeMounts": [
@@ -295,7 +296,7 @@
       "serviceAccountName": "jobs-qa-anvil-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/manifest-indexing:2021.06",
+        "image": "quay.io/cdis/manifest-indexing:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -336,7 +337,7 @@
       "serviceAccountName": "jobs-qa-anvil-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/download-indexd-manifest:2021.06",
+        "image": "quay.io/cdis/download-indexd-manifest:2023.12",
         "pull_policy": "Always",
         "env": [
           {

--- a/qa-bloodpac.planx-pla.net/manifest.json
+++ b/qa-bloodpac.planx-pla.net/manifest.json
@@ -4,35 +4,35 @@
     "That's all I have to say."
   ],
   "versions": {
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2022.08",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2022.07",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2022.08",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2022.08",
-    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2022.08",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:feat_serial-id2",
-    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2022.08",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2022.08",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2022.08",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2022.08",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.12",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
+    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2023.12",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.12",
+    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.12",
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.12",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "jupyterhub": "quay.io/occ_data/jupyterhub:2022.08",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2022.08",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2022.08",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2022.08",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2022.08",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2022.08",
+    "jupyterhub": "quay.io/occ_data/jupyterhub:2023.12",
+    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.12",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.12",
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.12",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.12",
+    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.12",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2022.08",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2022.08",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2022.08"
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.12",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.12",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.12"
   },
   "indexd": {
     "arborist": "true"
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2022.08"
+      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.12"
     }
   },
   "arborist": {
@@ -46,7 +46,7 @@
       "serviceAccountName": "jobs-qa-bloodpac-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifest-indexing:2022.08",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifest-indexing:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -111,7 +111,8 @@
     "netpolicy": "on",
     "kube_bucket": "kube-qaplanetv1-gen3",
     "logs_bucket": "logs-qaplanetv1-gen3",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-brain.planx-pla.net/manifest.json
+++ b/qa-brain.planx-pla.net/manifest.json
@@ -8,25 +8,25 @@
   },
   "versions": {
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "manifestservice": "quay.io/cdis/manifestservice:integration202106",
-    "arborist": "quay.io/cdis/arborist:integration202106",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
     "dashboard": "quay.io/cdis/gen3-statics:integration202103",
-    "hatchery": "quay.io/cdis/hatchery:integration202106",
-    "fence": "quay.io/cdis/fence:integration202106",
-    "indexd": "quay.io/cdis/indexd:integration202106",
-    "peregrine": "quay.io/cdis/peregrine:integration202106",
-    "pidgin": "quay.io/cdis/pidgin:integration202106",
-    "revproxy": "quay.io/cdis/nginx:integration202106",
-    "sheepdog": "quay.io/cdis/sheepdog:integration202106",
-    "portal": "quay.io/cdis/data-portal:integration202106",
+    "hatchery": "quay.io/cdis/hatchery:2023.12",
+    "fence": "quay.io/cdis/fence:2023.12",
+    "indexd": "quay.io/cdis/indexd:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:integration202106",
-    "spark": "quay.io/cdis/gen3-spark:integration202106",
-    "tube": "quay.io/cdis/tube:integration202106",
-    "guppy": "quay.io/cdis/guppy:integration202106",
-    "wts": "quay.io/cdis/workspace-token-service:integration202106",
-    "metadata": "quay.io/cdis/metadata-service:integration202106"
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2023.12",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "wts": "quay.io/cdis/workspace-token-service:2023.12",
+    "metadata": "quay.io/cdis/metadata-service:2023.12"
   },
   "arborist": {
     "deployment_version": "2"
@@ -63,11 +63,12 @@
     "tier_access_level": "regular",
     "tier_access_limit": "50",
     "public_datasets": true,
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:integration202106"
+      "indexing": "quay.io/cdis/indexs3client:2023.12"
     }
   },
   "canary": {

--- a/qa-brh.planx-pla.net/manifest.json
+++ b/qa-brh.planx-pla.net/manifest.json
@@ -45,7 +45,8 @@
     "tier_access_level": "regular",
     "tier_access_limit": 50,
     "public_datasets": true,
-    "netpolicy": "on"
+    "netpolicy": "on",
+    "es7": true
   },
   "metadata": {
     "USE_AGG_MDS": true,

--- a/qa-canine.planx-pla.net/manifest.json
+++ b/qa-canine.planx-pla.net/manifest.json
@@ -7,24 +7,24 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.03",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.03",
-    "indexd": "quay.io/cdis/indexd:2020.03",
-    "peregrine": "quay.io/cdis/peregrine:2020.03",
-    "pidgin": "quay.io/cdis/pidgin:2020.03",
+    "fence": "quay.io/cdis/fence:2023.12",
+    "indexd": "quay.io/cdis/indexd:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.03",
-    "portal": "quay.io/cdis/data-portal:2020.03",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
-    "spark": "quay.io/cdis/gen3-spark:2020.03",
-    "tube": "quay.io/cdis/tube:2020.03",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.03",
-    "guppy": "quay.io/cdis/guppy:2020.03",
-    "sower": "quay.io/cdis/sower:2020.03",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2023.12",
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "sower": "quay.io/cdis/sower:2023.12",
     "dashboard": "quay.io/cdis/gen3-statics:master",
-    "metadata": "quay.io/cdis/metadata-service:master"
+    "metadata": "quay.io/cdis/metadata-service:2023.12"
   },
   "sower": [
     {
@@ -118,7 +118,8 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "10",
     "netpolicy": "on",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-covid19.planx-pla.net/manifest.json
+++ b/qa-covid19.planx-pla.net/manifest.json
@@ -5,31 +5,31 @@
   ],
   "versions": {
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.05",
-    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.05",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.12",
+    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.12",
     "auspice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-auspice:v2.25.gen3.2.15",
     "aws-es-proxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/aws-es-proxy:v1.3.1",
-    "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2023.05",
+    "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2023.12",
     "covid19-bayes": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-bayes:5.1.4",
     "covid19-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-etl:5.2.4",
     "covid19-notebook-etl": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/covid19-notebook-etl:5.1.6",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.05",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.05",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.12",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.05",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.05",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.05",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.05",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.05",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.05",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.12",
+    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.12",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.12",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.12",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:automatedCopy-feat_b3_walder_discovery_prc",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.05",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.05",
-    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2023.05",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.05",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.05",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.05",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.05"
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.12",
+    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2023.12",
+    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.12",
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.12",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.12",
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.12"
   },
   "global": {
     "environment": "qa-covid19",
@@ -48,7 +48,8 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa-covid19/user.yaml",
     "covid19_data_bucket": "s3://static.planx-pla.net",
     "maintenance_mode": "off",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "portal": {
     "GEN3_BUNDLE": "covid19"
@@ -64,7 +65,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.05"
+      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.12"
     }
   },
   "sower": [
@@ -73,7 +74,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2023.05",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -150,7 +151,7 @@
       "serviceAccountName": "jobs-qa-covid19-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifest-indexing:2023.05",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifest-indexing:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -190,7 +191,7 @@
       "serviceAccountName": "jobs-qa-covid19-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/download-indexd-manifest:2023.05",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/download-indexd-manifest:2023.12",
         "pull_policy": "Always",
         "env": [
           {

--- a/qa-dcfdemo.planx-pla.net/manifest.json
+++ b/qa-dcfdemo.planx-pla.net/manifest.json
@@ -7,25 +7,25 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.03",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.03",
+    "fence": "quay.io/cdis/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "indexd": "quay.io/cdis/indexd:2020.03",
+    "indexd": "quay.io/cdis/indexd:2023.12",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
-    "peregrine": "quay.io/cdis/peregrine:2020.03",
-    "pidgin": "quay.io/cdis/pidgin:2020.03",
-    "portal": "quay.io/cdis/data-portal:2020.03",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.03",
-    "spark": "quay.io/cdis/gen3-spark:2020.03",
-    "tube": "quay.io/cdis/tube:2020.03",
-    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2020.03",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "ssjdispatcher": "quay.io/cdis/ssjdispatcher:2023.12",
     "dashboard": "quay.io/cdis/gen3-statics:master",
-    "guppy": "quay.io/cdis/guppy:2020.03",
-    "hatchery": "quay.io/cdis/hatchery:2020.03",
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "hatchery": "quay.io/cdis/hatchery:2023.12",
     "ambassador": "quay.io/datawire/ambassador:0.60.3",
-    "wts": "quay.io/cdis/workspace-token-service:2020.03",
+    "wts": "quay.io/cdis/workspace-token-service:2023.12",
     "manifestservice": "quay.io/cdis/manifestservice:0.2.0"
   },
   "indexd": {
@@ -129,7 +129,8 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "10",
     "netpolicy": "on",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -339,7 +339,8 @@
     "tier_access_level": "regular",
     "tier_access_limit": 50,
     "lb_type": "internal",
-    "dd_enabled": true
+    "dd_enabled": true,
+    "es7": true
   },
   "indexd": {
     "arborist": "true"

--- a/qa-flu.planx-pla.net/manifest.json
+++ b/qa-flu.planx-pla.net/manifest.json
@@ -4,22 +4,22 @@
     "goes with qa-tb.planx-pla.net, qa-nde.planx-pla.net and qa-aids.planx-pla.net"
   ],
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.08",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.08",
+    "fence": "quay.io/cdis/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "indexd": "quay.io/cdis/indexd:2020.08",
-    "manifestservice": "quay.io/cdis/manifestservice:2020.08",
-    "peregrine": "quay.io/cdis/peregrine:2020.08",
-    "pidgin": "quay.io/cdis/pidgin:2020.08",
-    "portal": "quay.io/cdis/data-portal:2020.08",
-    "revproxy": "quay.io/cdis/nginx:2020.08",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.08",
-    "sower": "quay.io/cdis/sower:2020.08",
-    "spark": "quay.io/cdis/gen3-spark:2020.08",
-    "tube": "quay.io/cdis/tube:2020.08",
-    "guppy": "quay.io/cdis/guppy:2020.08",
-    "dashboard": "quay.io/cdis/gen3-statics:2020.08"
+    "indexd": "quay.io/cdis/indexd:2023.12",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "sower": "quay.io/cdis/sower:2023.12",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "dashboard": "quay.io/cdis/gen3-statics:2023.12"
   },
   "global": {
     "dispatcher_job_num": "10",
@@ -46,7 +46,8 @@
     "netpolicy": "off",
     "cookie_domain": "planx-pla.net",
     "des_namespace": "qa-nde",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "arborist": {
     "deployment_version": "2"
@@ -79,7 +80,7 @@
     "name": "pelican-export",
     "container": {
       "name": "job-task",
-      "image": "quay.io/cdis/pelican:2020.08",
+      "image": "quay.io/cdis/pelican:2023.12",
       "pull_policy": "always",
       "env": [],
       "cpu-limit": "1",

--- a/qa-heal.planx-pla.net/manifest.json
+++ b/qa-heal.planx-pla.net/manifest.json
@@ -59,7 +59,8 @@
     "netpolicy": "on",
     "lb_type": "internal",
     "document_url": "https://heal.github.io/platform-documentation",
-    "frontend_root": "gen3ff"
+    "frontend_root": "gen3ff",
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-ibd.planx-pla.net/manifest.json
+++ b/qa-ibd.planx-pla.net/manifest.json
@@ -175,7 +175,8 @@
     "lb_type": "internal",
     "public_datasets": true,
     "karpenter": true,
-    "argocd": true
+    "argocd": true,
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-jcoin.planx-pla.net/manifest.json
+++ b/qa-jcoin.planx-pla.net/manifest.json
@@ -4,26 +4,26 @@
     "That's all I have to say."
   ],
   "versions": {
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.11",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.12",
     "aws-es-proxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/aws-es-proxy:v1.3.1",
-    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.11",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.11",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.11",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.11",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.11",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.11",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.11",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.11",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.11",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.11",
+    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.12",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.12",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.12",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.12",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.12",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.12",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.11",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.11",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.11",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.11",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.11",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.11",
-    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2023.11",
+    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.12",
+    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.12",
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.12",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.12",
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.12",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.12",
+    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2023.12",
     "ambassador": "quay.io/datawire/ambassador:1.4.2"
   },
   "guppy": {
@@ -61,7 +61,8 @@
     "dispatcher_job_num": "10",
     "netpolicy": "on",
     "maintenance_mode": "off",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "canary": {
     "default": 0
@@ -74,7 +75,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.11"
+      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.12"
     }
   },
   "sower": [
@@ -85,7 +86,7 @@
       "serviceAccountName": "jobs-qa-jcoin-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-manifest-ingestion:2023.11",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-manifest-ingestion:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -125,7 +126,7 @@
       "serviceAccountName": "jobs-qa-jcoin-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/get-dbgap-metadata:2023.11",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/get-dbgap-metadata:2023.12",
         "pull_policy": "Always",
         "env": [],
         "volumeMounts": [
@@ -156,7 +157,7 @@
       "serviceAccountName": "jobs-qa-jcoin-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifest-indexing:2023.11",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifest-indexing:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -197,7 +198,7 @@
       "serviceAccountName": "jobs-qa-jcoin-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/cdis/manifest-merging:2023.11",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/cdis/manifest-merging:2023.12",
         "pull_policy": "Always",
         "env": [
           {
@@ -238,7 +239,7 @@
       "serviceAccountName": "jobs-qa-jcoin-planx-pla-net",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/download-indexd-manifest:2023.11",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/download-indexd-manifest:2023.12",
         "pull_policy": "Always",
         "env": [
           {

--- a/qa-kidsfirst.planx-pla.net/manifest.json
+++ b/qa-kidsfirst.planx-pla.net/manifest.json
@@ -7,17 +7,17 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.05",
-    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.05",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.05",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.12",
+    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.12",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.12",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:9.1.0",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.05",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.05",
-    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.05",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.05",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.05",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.05",
-    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.05",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
+    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.12",
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.12",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.12",
+    "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0"
   },
   "arborist": {
@@ -39,7 +39,8 @@
     "dispatcher_job_num": "10",
     "netpolicy": "on",
     "maintenance_mode": "off",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -8,25 +8,25 @@
   },
   "versions": {
     "ambassador": "quay.io/datawire/ambassador:1.14.4",
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.10",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.12",
     "argo-wrapper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/argo-wrapper:master",
-    "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2023.10",
+    "awshelper": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:2023.12",
     "cohort-middleware": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/cohort-middleware:master",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.10",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.10",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.12",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.10",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.10",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.10",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.10",
+    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.12",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.12",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.12",
     "ohdsi-atlas": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-atlas:2.14.0_PRE",
     "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:feat_add_team_project_access_control",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.10",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:feat_vadc_sprint22",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.10",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.10",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.10",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.10"
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.12",
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.12",
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.12"
   },
   "arborist": {
     "deployment_version": "2"
@@ -36,7 +36,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.10"
+      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.12"
     }
   },
   "global": {
@@ -52,7 +52,8 @@
     "dispatcher_job_num": "10",
     "netpolicy": "on",
     "lb_type": "internal",
-    "arborist_url": "http://arborist-service"
+    "arborist_url": "http://arborist-service",
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-microbiome.planx-pla.net/manifest.json
+++ b/qa-microbiome.planx-pla.net/manifest.json
@@ -4,23 +4,23 @@
     "goes with qa-tb.planx-pla.net, qa-nde.planx-pla.net and qa-flu.planx-pla.net, qa-aids.planx-pla.net"
   ],
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.08",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.08",
+    "fence": "quay.io/cdis/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "indexd": "quay.io/cdis/indexd:2020.08",
-    "manifestservice": "quay.io/cdis/manifestservice:2020.08",
-    "peregrine": "quay.io/cdis/peregrine:2020.08",
-    "pidgin": "quay.io/cdis/pidgin:2020.08",
-    "portal": "quay.io/cdis/data-portal:2020.08",
-    "revproxy": "quay.io/cdis/nginx:2020.08",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.08",
-    "sower": "quay.io/cdis/sower:2020.08",
-    "spark": "quay.io/cdis/gen3-spark:2020.08",
-    "tube": "quay.io/cdis/tube:2020.08",
-    "wts": "quay.io/cdis/workspace-token-service:2020.08",
-    "dashboard": "quay.io/cdis/gen3-statics:2020.08",
-    "guppy": "quay.io/cdis/guppy:2020.08"
+    "indexd": "quay.io/cdis/indexd:2023.12",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "sower": "quay.io/cdis/sower:2023.12",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "wts": "quay.io/cdis/workspace-token-service:2023.12",
+    "dashboard": "quay.io/cdis/gen3-statics:2023.12",
+    "guppy": "quay.io/cdis/guppy:2023.12"
   },
   "global": {
     "dispatcher_job_num": "10",
@@ -48,7 +48,8 @@
     "netpolicy": "off",
     "cookie_domain": "planx-pla.net",
     "des_namespace": "qa-nde",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "arborist": {
     "deployment_version": "2"
@@ -63,7 +64,7 @@
     "name": "pelican-export",
     "container": {
       "name": "job-task",
-      "image": "quay.io/cdis/pelican:2020.08",
+      "image": "quay.io/cdis/pelican:2023.12",
       "pull_policy": "always",
       "env": [],
       "cpu-limit": "1",
@@ -73,7 +74,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2020.08"
+      "indexing": "quay.io/cdis/indexs3client:2023.12"
     }
   },
   "canary": {

--- a/qa-midrc.planx-pla.net/manifest.json
+++ b/qa-midrc.planx-pla.net/manifest.json
@@ -5,26 +5,26 @@
   ],
   "versions": {
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.10",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:v1.3.1",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.10",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.12",
     "dicom-viewer": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohif-viewer:gen3-0.1.2",
     "dicom-server": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-orthanc:gen3-0.1.1",
-    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.10",
+    "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.10",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.10",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.10",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.10",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.10",
+    "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.12",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.12",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.12",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.16.0",
     "frontend-framework": "quay.io/cdis/frontend-framework:feat_n3c",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.10",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.10",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.10",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.10",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.10",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.10"
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.12",
+    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.12",
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.12",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.12",
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.12"
   },
   "arborist": {
     "deployment_version": "2"
@@ -40,7 +40,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.10"
+      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.12"
     }
   },
   "guppy": {
@@ -85,7 +85,8 @@
     "dictionary_url": "http://s3.amazonaws.com/dictionary-artifacts/midrc_dictionary/1.2.5/schema.json",
     "sync_from_dbgap": "False",
     "frontend_root": "portal",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-nde.planx-pla.net/manifest.json
+++ b/qa-nde.planx-pla.net/manifest.json
@@ -5,20 +5,20 @@
   ],
   "versions": {
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "arborist": "quay.io/cdis/arborist:2020.08",
-    "fence": "quay.io/cdis/fence:2020.08",
-    "indexd": "quay.io/cdis/indexd:2020.08",
+    "arborist": "quay.io/cdis/arborist:2023.12",
+    "fence": "quay.io/cdis/fence:2023.12",
+    "indexd": "quay.io/cdis/indexd:2023.12",
     "portal": "quay.io/cdis/data-ecosystem-portal:1.2.4",
-    "revproxy": "quay.io/cdis/nginx:2020.08",
-    "dashboard": "quay.io/cdis/gen3-statics:2020.08",
-    "wts": "quay.io/cdis/workspace-token-service:2020.08",
-    "manifestservice": "quay.io/cdis/manifestservice:2020.08",
-    "hatchery": "quay.io/cdis/hatchery:2020.08",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
+    "dashboard": "quay.io/cdis/gen3-statics:2023.12",
+    "wts": "quay.io/cdis/workspace-token-service:2023.12",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "hatchery": "quay.io/cdis/hatchery:2023.12",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
-    "guppy": "quay.io/cdis/guppy:2020.08",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.08",
-    "peregrine": "quay.io/cdis/peregrine:2020.08",
-    "pidgin": "quay.io/cdis/pidgin:2020.08"
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12"
   },
   "arborist": {
     "deployment_version": "2"
@@ -47,11 +47,12 @@
     "cookie_domain": "planx-pla.net",
     "public_datasets": true,
     "tier_access_level": "libre",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2020.08"
+      "indexing": "quay.io/cdis/indexs3client:2023.12"
     }
   },
   "canary": {

--- a/qa-niaid.planx-pla.net/manifest.json
+++ b/qa-niaid.planx-pla.net/manifest.json
@@ -7,29 +7,29 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.05",
-    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.05",
+    "arborist": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/arborist:2023.12",
+    "audit-service": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/audit-service:2023.12",
     "aws-es-proxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/aws-es-proxy:v1.3.1",
-    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.05",
+    "dashboard": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-statics:2023.12",
     "fence": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/fence:8.0.0",
-    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.05",
-    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.05",
-    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.05",
-    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.05",
-    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.05",
-    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2023.05",
+    "indexd": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexd:2023.12",
+    "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
+    "pidgin": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pidgin:2023.12",
+    "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",
+    "sheepdog": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sheepdog:2023.12",
+    "sower": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/sower:2023.12",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:5.18.0",
-    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.05",
+    "tube": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/tube:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.05",
-    "requestor": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/requestor:2023.05",
-    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.05",
-    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.05",
+    "spark": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/gen3-spark:2023.12",
+    "requestor": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/requestor:2023.12",
+    "hatchery": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/hatchery:2023.12",
+    "wts": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/workspace-token-service:2023.12",
     "ambassador": "quay.io/datawire/ambassador:1.4.2",
     "guppy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/guppy:2023.10",
-    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.05",
-    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.05",
-    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.05"
+    "ssjdispatcher": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ssjdispatcher:2023.12",
+    "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.12",
+    "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.12"
   },
   "arborist": {
     "deployment_version": "2"
@@ -39,7 +39,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.05"
+      "indexing": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/indexs3client:2023.12"
     }
   },
   "global": {
@@ -57,7 +57,8 @@
     "tier_access_level": "libre",
     "public_datasets": true,
     "maintenance_mode": "off",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "canary": {
     "default": 0
@@ -89,7 +90,7 @@
       "action": "export",
       "container": {
         "name": "job-task",
-        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2023.05",
+        "image": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/pelican-export:2023.12",
         "pull_policy": "Always",
         "env": [
           {

--- a/qa-tb.planx-pla.net/manifest.json
+++ b/qa-tb.planx-pla.net/manifest.json
@@ -4,22 +4,22 @@
     "goes with qa-nde.planx-pla.net, qa-aids.planx-pla.net and qa-flu.planx-pla.net"
   ],
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2020.08",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2020.08",
+    "fence": "quay.io/cdis/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "guppy": "quay.io/cdis/guppy:2020.08",
-    "indexd": "quay.io/cdis/indexd:2020.08",
-    "manifestservice": "quay.io/cdis/manifestservice:2020.08",
-    "peregrine": "quay.io/cdis/peregrine:2020.08",
-    "pidgin": "quay.io/cdis/pidgin:2020.08",
-    "portal": "quay.io/cdis/data-portal:2020.08",
-    "revproxy": "quay.io/cdis/nginx:2020.08",
-    "sheepdog": "quay.io/cdis/sheepdog:2020.08",
-    "sower": "quay.io/cdis/sower:2020.08",
-    "spark": "quay.io/cdis/gen3-spark:2020.08",
-    "tube": "quay.io/cdis/tube:2020.08",
-    "dashboard": "quay.io/cdis/gen3-statics:2020.08"
+    "guppy": "quay.io/cdis/guppy:2023.12",
+    "indexd": "quay.io/cdis/indexd:2023.12",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "sower": "quay.io/cdis/sower:2023.12",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "tube": "quay.io/cdis/tube:2023.12",
+    "dashboard": "quay.io/cdis/gen3-statics:2023.12"
   },
   "global": {
     "dispatcher_job_num": "10",
@@ -46,7 +46,8 @@
     "netpolicy": "off",
     "cookie_domain": "planx-pla.net",
     "des_namespace": "qa-nde",
-    "lb_type": "internal"
+    "lb_type": "internal",
+    "es7": true
   },
   "arborist": {
     "deployment_version": "2"
@@ -89,7 +90,7 @@
   },
   "ssjdispatcher": {
     "job_images": {
-      "indexing": "quay.io/cdis/indexs3client:2020.08"
+      "indexing": "quay.io/cdis/indexs3client:2023.12"
     }
   },
   "canary": {

--- a/qa.planx-pla.net/manifest.json
+++ b/qa.planx-pla.net/manifest.json
@@ -7,21 +7,21 @@
     "autodeploy": "yes"
   },
   "versions": {
-    "acronymbot": "quay.io/cdis/acronym-bot:master",
-    "arborist": "quay.io/cdis/arborist:master",
+    "acronymbot": "quay.io/cdis/acronym-bot:2023.12",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:v1.3.1",
-    "dashboard": "quay.io/cdis/gen3-statics:master",
-    "fence": "quay.io/cdis/fence:master",
+    "dashboard": "quay.io/cdis/gen3-statics:2023.12",
+    "fence": "quay.io/cdis/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0",
-    "jenkins": "quay.io/cdis/jenkins:master",
-    "jenkins-worker": "quay.io/cdis/gen3-qa-worker:master",
-    "jenkins-ci-worker": "quay.io/cdis/gen3-ci-worker:master",
-    "peregrine": "quay.io/cdis/peregrine:master",
-    "portal": "quay.io/cdis/data-portal:master",
-    "qabot": "quay.io/cdis/qa-bot:master",
-    "revproxy": "quay.io/cdis/nginx:master",
-    "sheepdog": "quay.io/cdis/sheepdog:master",
-    "thor": "quay.io/cdis/thor:master"
+    "jenkins": "quay.io/cdis/jenkins:2023.12",
+    "jenkins-worker": "quay.io/cdis/gen3-qa-worker:2023.12",
+    "jenkins-ci-worker": "quay.io/cdis/gen3-ci-worker:2023.12",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
+    "qabot": "quay.io/cdis/qa-bot:2023.12",
+    "revproxy": "quay.io/cdis/nginx:2023.12",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "thor": "quay.io/cdis/thor:2023.12"
   },
   "arborist": {
     "deployment_version": "2"
@@ -38,7 +38,8 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "netpolicy": "off-for-jenkins",
     "lb_type": "internal",
-    "karpenter": true
+    "karpenter": true,
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qaplanetv2.planx-pla.net/manifest.json
+++ b/qaplanetv2.planx-pla.net/manifest.json
@@ -4,20 +4,20 @@
     "That's all I have to say"
   ],
   "versions": {
-    "arborist": "quay.io/cdis/arborist:2021.01",
+    "arborist": "quay.io/cdis/arborist:2023.12",
     "aws-es-proxy": "quay.io/cdis/aws-es-proxy:0.8",
-    "fence": "quay.io/cdis/fence:2021.01",
+    "fence": "quay.io/cdis/fence:2023.12",
     "fluentd": "fluent/fluentd-kubernetes-daemonset:v1.10.2-debian-cloudwatch-1.0",
-    "indexd": "quay.io/cdis/indexd:2021.01",
+    "indexd": "quay.io/cdis/indexd:2023.12",
     "jupyterhub": "quay.io/occ_data/jupyterhub:master",
-    "peregrine": "quay.io/cdis/peregrine:2021.01",
-    "pidgin": "quay.io/cdis/pidgin:2021.01",
-    "portal": "quay.io/cdis/data-portal:2021.01",
+    "peregrine": "quay.io/cdis/peregrine:2023.12",
+    "pidgin": "quay.io/cdis/pidgin:2023.12",
+    "portal": "quay.io/cdis/data-portal:2023.12",
     "revproxy": "quay.io/cdis/nginx:1.17.6-ctds-1.0.1",
-    "sheepdog": "quay.io/cdis/sheepdog:2021.01",
-    "spark": "quay.io/cdis/gen3-spark:2021.01",
-    "manifestservice": "quay.io/cdis/manifestservice:2021.01",
-    "wts": "quay.io/cdis/workspace-token-service:2021.01",
+    "sheepdog": "quay.io/cdis/sheepdog:2023.12",
+    "spark": "quay.io/cdis/gen3-spark:2023.12",
+    "manifestservice": "quay.io/cdis/manifestservice:2023.12",
+    "wts": "quay.io/cdis/workspace-token-service:2023.12",
     "tube": "quay.io/cdis/tube:master"
   },
   "arranger": {
@@ -45,7 +45,8 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "netpolicy": "on",
     "lb_type": "internal",
-    "argocd": "true"
+    "argocd": "true",
+    "es7": true
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
### Description of changes
I am updating all qa environments to release 2023.12 which contains Guppy, Tube, and Metadata images that are compatible with ES7. I am also adding the "ES7: true" flag to the global sections of the manifests so these environments will point to the new cluster. 