### PR TITLE
adding the "es7 flag" to all qa environments using the latest release.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -6922,7 +6922,7 @@
         "filename": "qa-heal.planx-pla.net/manifest.json",
         "hashed_secret": "ae4a2a671a528744059cd818de9af9e13005563b",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 106
       }
     ],
     "qa-heal.planx-pla.net/metadata/aggregate_config.json": [
@@ -7620,5 +7620,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-26T17:01:01Z"
+  "generated_at": "2023-11-30T15:24:12Z"
 }

--- a/qa-brh.planx-pla.net/manifest.json
+++ b/qa-brh.planx-pla.net/manifest.json
@@ -45,7 +45,8 @@
     "tier_access_level": "regular",
     "tier_access_limit": 50,
     "public_datasets": true,
-    "netpolicy": "on"
+    "netpolicy": "on",
+    "es7": true
   },
   "metadata": {
     "USE_AGG_MDS": true,

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -339,7 +339,8 @@
     "tier_access_level": "regular",
     "tier_access_limit": 50,
     "lb_type": "internal",
-    "dd_enabled": true
+    "dd_enabled": true,
+    "es7": true
   },
   "indexd": {
     "arborist": "true"

--- a/qa-heal.planx-pla.net/manifest.json
+++ b/qa-heal.planx-pla.net/manifest.json
@@ -59,7 +59,8 @@
     "netpolicy": "on",
     "lb_type": "internal",
     "document_url": "https://heal.github.io/platform-documentation",
-    "frontend_root": "gen3ff"
+    "frontend_root": "gen3ff",
+    "es7": true
   },
   "canary": {
     "default": 0

--- a/qa-ibd.planx-pla.net/manifest.json
+++ b/qa-ibd.planx-pla.net/manifest.json
@@ -175,7 +175,8 @@
     "lb_type": "internal",
     "public_datasets": true,
     "karpenter": true,
-    "argocd": true
+    "argocd": true,
+    "es7": true
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
The latest release is not compatible with ES6, so we need a flag to point these environments at ES7.

### Environments
qa-brh, qa-dcp, qa-heal, qa-ibd

### Description of changes
addition of the global es7: true flag
