### PR TITLE
jenkins-dcp ES7 re-enabled

### DIFF
--- a/jenkins-dcp.planx-pla.net/manifest.json
+++ b/jenkins-dcp.planx-pla.net/manifest.json
@@ -278,7 +278,8 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "dispatcher_job_num": "5",
     "netpolicy": "on",
-    "tier_access_level" : "libre"
+    "tier_access_level" : "libre",
+    "es7": true
   },
   "ssjdispatcher": {
     "job_images": {


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- jenkins-dcp

### Description of changes
- Re-enabling ES7 for jenkins-dcp now that commons have migrated from ES6.