### PR TITLE
Feat: move WebAPI to 2.15.0-DEV branch on QA

### DIFF
--- a/qa-mickey.planx-pla.net/manifest.json
+++ b/qa-mickey.planx-pla.net/manifest.json
@@ -20,7 +20,7 @@
     "manifestservice": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/manifestservice:2023.12",
     "metadata": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/metadata-service:2023.12",
     "ohdsi-atlas": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-atlas:2.15.0-DEV",
-    "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:feat_add_team_project_access_control",
+    "ohdsi-webapi": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/ohdsi-webapi:2.15.0-DEV",
     "peregrine": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/peregrine:2023.12",
     "portal": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/data-portal:feat_vadc_sprint09",
     "revproxy": "707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/nginx:2023.12",


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
- VA QA

### Description of changes
- Run WebAPI from 2.15.0-DEV branch on QA