### PR TITLE
Fix: adjust atlas URL to just hostname

### DIFF
--- a/qa-mickey.planx-pla.net/portal/gitops.json
+++ b/qa-mickey.planx-pla.net/portal/gitops.json
@@ -93,7 +93,7 @@
     {
       "title": "OHDSI Atlas",
       "description": "Use this App for cohort creation. These will be automatically populated in the Gen3 GWAS App",
-      "applicationUrl": "https://atlas.qa-mickey.planx-pla.net/atlas/",
+      "applicationUrl": "https://atlas.qa-mickey.planx-pla.net",
       "image": "/custom/sponsors/gitops-sponsors/atlas-logo.png",
       "needsTeamProject": true
     },


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1221

### Environments
- VA QA

### Description of changes
- adjust atlas URL to just hostname which gives more flexibility to adjust final URL in the portal code itself