### PR TITLE
Add 'index_file' to qa BDC guppy indices

### DIFF
--- a/qa-dcp.planx-pla.net/etlMapping.yaml
+++ b/qa-dcp.planx-pla.net/etlMapping.yaml
@@ -112,7 +112,7 @@ mappings:
       - path: studies[studies_submitter_id:submitter_id].projects[code]
       - path: studies[studies_submitter_id:submitter_id].projects[code].programs[programs_name:name]
     joining_props:
-      - index: file
+      - index: data_file
         join_on: _subject_id
         props:
           - name: data_format
@@ -121,8 +121,20 @@ mappings:
           - name: data_type
             src: data_type
             fn: set
-          - name: file_count
-            src: _file_id
+          - name: data_file_count
+            src: _data_file_id
+            fn: count
+      - index: index_file
+        join_on: _subject_id
+        props:
+          - name: data_format
+            src: data_format
+            fn: set
+          - name: data_type
+            src: data_type
+            fn: set
+          - name: index_file_count
+            src: _index_file_id
             fn: count
   - name: qa-dcp_data_file
     doc_type: data_file
@@ -166,6 +178,7 @@ mappings:
       - name: data_category
       - name: data_format
       - name: data_type
+      - name: state
       - name: callset
       - name: bucket_path
       - name: source_node

--- a/qa-dcp.planx-pla.net/etlMapping.yaml
+++ b/qa-dcp.planx-pla.net/etlMapping.yaml
@@ -166,7 +166,6 @@ mappings:
       - name: data_category
       - name: data_format
       - name: data_type
-      - name: state
       - name: callset
       - name: bucket_path
       - name: source_node

--- a/qa-dcp.planx-pla.net/etlMapping.yaml
+++ b/qa-dcp.planx-pla.net/etlMapping.yaml
@@ -124,11 +124,40 @@ mappings:
           - name: file_count
             src: _file_id
             fn: count
-  - name: qa-dcp_file
-    doc_type: file
+  - name: qa-dcp_data_file
+    doc_type: data_file
     type: collector
     root: None
     category: data_file
+    props:
+      - name: object_id
+      - name: md5sum
+      - name: file_name
+      - name: file_size
+      - name: data_category
+      - name: data_format
+      - name: data_type
+      - name: state
+      - name: callset
+      - name: bucket_path
+      - name: source_node
+    injecting_props:
+      subject:
+        props:
+          - name: _subject_id
+            src: id
+            fn: set
+          - name: project_id
+      program:
+        props:
+          - name: programs_name
+            src: name
+            fn: set
+  - name: qa-dcp_index_file
+    doc_type: index_file
+    type: collector
+    root: None
+    category: index_file
     props:
       - name: object_id
       - name: md5sum

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -355,8 +355,12 @@
         "type": "subject"
       },
       {
-        "index": "qa-dcp_file",
-        "type": "file"
+        "index": "qa-dcp_data_file",
+        "type": "data_file"
+      },
+      {
+        "index": "qa-dcp_index_file",
+        "type": "index_file"
       }
     ],
     "config_index": "qa-dcp_array-config",

--- a/qa-dcp.planx-pla.net/manifest.json
+++ b/qa-dcp.planx-pla.net/manifest.json
@@ -277,11 +277,11 @@
           },
           {
             "name": "ROOT_NODE",
-            "value": "file"
+            "value": "data_file"
           },
           {
             "name": "EXTRA_NODES",
-            "value": ""
+            "value": "index_file"
           }
         ],
         "volumeMounts": [


### PR DESCRIPTION
Link to Jira ticket if there is one: [BDC-332](https://ctds-planx.atlassian.net/browse/BDC-332)

### Environments

-BDC: [qa-dcp.planx-pla.net](https://qa-dcp.planx-pla.net/)

### Description of changes
**etlMapping.yaml**:
- Change `file` index to `data_file`
- Add `index_file` guppy index

**manifest.json**:
- Change `file` index to `data_file`
- Add `index_file` guppy index

[BDC-332]: https://ctds-planx.atlassian.net/browse/BDC-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ