### PR TITLE
remove old `augmented` HEAL jupyter ws

### DIFF
--- a/qa-heal.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-heal.planx-pla.net/manifests/hatchery/hatchery.json
@@ -169,37 +169,5 @@
       "user-volume-location": "/home/jovyan/pd",
       "gen3-volume-location": "/home/jovyan/.gen3"
     },
-    {
-      "target-port": 8888,
-      "cpu-limit": "1.0",
-      "memory-limit": "2Gi",
-      "name": "(Generic) Augmented Jupyter Lab Notebook",
-      "image": "quay.io/cdis/heal-notebooks:lab_extensions__e9a4a6fc610b21aaf5d08e88ec5483bee4fac821",
-      "env": {
-        "FRAME_ANCESTORS": "https://qa-heal.planx-pla.net"
-      },
-      "args": [
-        "--NotebookApp.base_url=/lw-workspace/proxy/",
-        "--NotebookApp.default_url=/lab",
-        "--NotebookApp.password=''",
-        "--NotebookApp.token=''",
-        "--NotebookApp.quit_button=False"
-      ],
-      "command": [
-        "start-notebook.sh"
-      ],
-      "path-rewrite": "/lw-workspace/proxy/",
-      "use-tls": "false",
-      "ready-probe": "/lw-workspace/proxy/",
-      "lifecycle-post-start": [
-        "/bin/sh",
-        "-c",
-        "export IAM=`whoami`; rm -rf /home/$IAM/pd/dockerHome; rm -rf /home/$IAM/pd/lost+found; ln -s /data /home/$IAM/pd/; true"
-      ],
-      "user-uid": 1000,
-      "fs-gid": 100,
-      "user-volume-location": "/home/jovyan/pd",
-      "gen3-volume-location": "/home/jovyan/.gen3"
-    }
   ]
 }


### PR DESCRIPTION
Link to Jira ticket if there is one: https://ctds-planx.atlassian.net/jira/software/c/projects/HP/boards/85/backlog?assignee=6077512a6576f4006843cc5b&selectedIssue=HP-1774 

### Environments
QA HEAL

### Description of changes
Remove a very old jupyter-lab workspace image that was once used to test jupyter-lab extensions in the HEAL workspace environment. Some of these extensions were carried over, but the testing and workspace flavor are no longer needed.