### PR TITLE
making changes for qa-heal to use IRSA for the batch-export job

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -6940,15 +6940,6 @@
         "line_number": 246
       }
     ],
-    "qa-heal.planx-pla.net/manifest.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "qa-heal.planx-pla.net/manifest.json",
-        "hashed_secret": "ae4a2a671a528744059cd818de9af9e13005563b",
-        "is_verified": false,
-        "line_number": 109
-      }
-    ],
     "qa-heal.planx-pla.net/metadata/aggregate_config.json": [
       {
         "type": "Hex High Entropy String",
@@ -7644,5 +7635,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-24T21:41:19Z"
+  "generated_at": "2024-11-12T19:13:31Z"
 }

--- a/qa-heal.planx-pla.net/manifest.json
+++ b/qa-heal.planx-pla.net/manifest.json
@@ -75,7 +75,7 @@
       "activeDeadlineSeconds": 600,
       "container": {
         "name": "job-task",
-        "image": "quay.io/cdis/batch-export:2024.10",
+        "image": "quay.io/cdis/batch-export:feat_GPE-1219",
         "pull_policy": "Always",
         "labels": {
           "internet": "yes"
@@ -89,27 +89,20 @@
                 "key": "hostname"
               }
             }
-          }
-        ],
-        "volumeMounts": [
+          },
           {
-            "name": "batch-export-creds-volume",
-            "readOnly": true,
-            "mountPath": "/batch-export-creds.json",
-            "subPath": "config.json"
-          }
+              "name": "BUCKET",
+              "valueFrom": {
+                "configMapKeyRef": {
+                  "name": "batch-export-sa",
+                  "key": "bucket_name"
+                }
+              }
+            }
         ],
         "cpu-limit": "1",
         "memory-limit": "1Gi"
       },
-      "volumes": [
-        {
-          "name": "batch-export-creds-volume",
-          "secret": {
-            "secretName": "batch-export-g3auto"
-          }
-        }
-      ],
       "restart_policy": "Never"
     }
   ],

--- a/qa-heal.planx-pla.net/manifest.json
+++ b/qa-heal.planx-pla.net/manifest.json
@@ -72,6 +72,7 @@
     {
       "name": "batch-export",
       "action": "batch-export",
+      "serviceAccountName": "batch-export-sa",
       "activeDeadlineSeconds": 600,
       "container": {
         "name": "job-task",
@@ -94,7 +95,7 @@
               "name": "BUCKET",
               "valueFrom": {
                 "configMapKeyRef": {
-                  "name": "batch-export-sa",
+                  "name": "batch-export-g3auto",
                   "key": "bucket_name"
                 }
               }


### PR DESCRIPTION
### Environments
qa-heal

### Description of changes
The batch export job now will rely on a service account instead of AWS access keys. This change is more secure and prevents any downtime caused by expired keys. In order to implement this change, we need to change the sower-job image as well as the volume mounts and environment variables to support the new batch export image. 