### PR TITLE
Remove karpenter provisioning for qaplanetv1

### DIFF
--- a/qa.planx-pla.net/manifest.json
+++ b/qa.planx-pla.net/manifest.json
@@ -38,7 +38,6 @@
     "useryaml_s3path": "s3://cdis-gen3-users/qa/user.yaml",
     "netpolicy": "off-for-jenkins",
     "lb_type": "internal",
-    "karpenter": true,
     "es7": true
   },
   "canary": {


### PR DESCRIPTION
Karpenter cleanup affects test run as pods can get deleted during test execution

Link to Jira ticket if there is one:

### Environments


### Description of changes
