### PR TITLE
new entry added for merged changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -7601,9 +7601,9 @@
         "filename": "qa-prometheus.planx-pla.net/metadata/aggregate_config.json",
         "hashed_secret": "39b47b995efe827977ba24921d94df23ba197a00",
         "is_verified": false,
-        "line_number": 508
+        "line_number": 511
       }
     ]
   },
-  "generated_at": "2025-06-27T17:07:29Z"
+  "generated_at": "2025-06-27T17:16:14Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -7601,9 +7601,9 @@
         "filename": "qa-prometheus.planx-pla.net/metadata/aggregate_config.json",
         "hashed_secret": "39b47b995efe827977ba24921d94df23ba197a00",
         "is_verified": false,
-        "line_number": 420
+        "line_number": 508
       }
     ]
   },
-  "generated_at": "2025-05-13T17:15:45Z"
+  "generated_at": "2025-06-27T17:07:29Z"
 }

--- a/qa-prometheus.planx-pla.net/metadata/aggregate_config.json
+++ b/qa-prometheus.planx-pla.net/metadata/aggregate_config.json
@@ -35,6 +35,10 @@
       "primary_site": {},
       "authz": {},
       "subject_id": {},
+      "subject_id_list" : {
+        "type": "array",
+        "default": []
+      },
       "subject_apollo_id": {},
       "subject_race": {},
       "subject_gender": {},
@@ -47,8 +51,11 @@
       "subject_primary_disease": {},
       "subject_type_of_exposure": {},
       "subject_chemical_agents_of_exposure": {},
-      "prometheus_global_id": {},
+      "mc2dp_global_id": {},
       "studies": {
+        "type": "array"
+      },
+      "data_files": {
         "type": "array"
       },
       "filesCount": {
@@ -358,7 +365,7 @@
         "subject_primary_disease": "path:primary_disease",
         "commons_url": "data.bloodpac.org",
         "data_source": "BLOODPAC",
-        "prometheus_global_id": "path:prometheus_global_id",
+        "mc2dp_global_id": "path:mc2dp_global_id",
         "is_synthetic": "Yes"
       }
     },
@@ -491,7 +498,7 @@
         },
         "commons_url": "vpodc.data-commons.org",
         "data_source": "VPODC",
-        "prometheus_global_id": "path:prometheus_global_id",
+        "mc2dp_global_id": "path:mc2dp_global_id",
         "is_synthetic": "No"
       },
       "per_item_values": {
@@ -794,7 +801,7 @@
         "subject_chemical_agents_of_exposure": "path:exposure_agent",
         "data_source": "path:data_source",
         "commons_url": "externalgen3.prometheus.data-commons.org",
-        "prometheus_global_id": "path:prometheus_global_id",
+        "mc2dp_global_id": "path:mc2dp_global_id",
         "is_synthetic": "Yes"
       }
     },
@@ -934,7 +941,7 @@
         "data_source": "path:data_source",
         "sub_data_source": "path:sub_data_source",
         "commons_url": "externalgen3.prometheus.data-commons.org",
-        "prometheus_global_id": "path:prometheus_global_id",
+        "mc2dp_global_id": "path:mc2dp_global_id",
         "is_synthetic": "No"
       }
     },
@@ -1045,7 +1052,7 @@
         "subject_primary_disease": "",
         "data_source": "TCIA",
         "commons_url": "externalgen3.prometheus.data-commons.org",
-        "prometheus_global_id": "path:prometheus_global_id",
+        "mc2dp_global_id": "path:mc2dp_global_id",
         "is_synthetic": "No",
         "studies": "path:studies.*"
       }
@@ -1111,8 +1118,33 @@
         "subject_primary_disease": "",
         "data_source": "Windber",
         "commons_url": "externalgen3.prometheus.data-commons.org",
-        "prometheus_global_id": "path:prometheus_global_id",
+        "mc2dp_global_id": "path:mc2dp_global_id",
         "is_synthetic": "Yes"
+      }
+    },
+    "aggregated-subject-level-metadata": {
+      "mds_url": "https://externalgen3.prometheus.data-commons.org/",
+      "commons_url": "externalgen3.prometheus.data-commons.org",
+      "adapter": "gen3",
+      "config": {
+        "guid_type": "aggmds_metadata_entry",
+        "study_field": "gen3_discovery"
+      },
+      "keep_original_fields": false,
+      "field_mappings": {
+        "authz": "",
+        "tags": "path:tags",
+        "_unique_id": "path:mc2dp_global_id",
+        "commons": "path:data_source",
+        "subject_id_list": "path:data_source_ids",
+        "subject_metastasis": "path:metastasis",
+        "subject_cancer_type": "path:cancer_type",
+        "subject_primary_disease": "path:primary_disease",
+        "data_source": "path:data_source",
+        "commons_url": "externalgen3.prometheus.data-commons.org",
+        "mc2dp_global_id": "path:mc2dp_global_id",
+        "is_synthetic": "No",
+        "data_files": "path:data_type"
       }
     }
   }

--- a/qa-prometheus.planx-pla.net/metadata/aggregate_config.json
+++ b/qa-prometheus.planx-pla.net/metadata/aggregate_config.json
@@ -50,6 +50,9 @@
       "subject_year_of_birth": {},
       "subject_primary_disease": {},
       "subject_type_of_exposure": {},
+      "subject_type_of_exposures" : {
+        "type": "array"
+      },
       "subject_chemical_agents_of_exposure": {},
       "mc2dp_global_id": {},
       "studies": {
@@ -1140,6 +1143,7 @@
         "subject_metastasis": "path:metastasis",
         "subject_cancer_type": "path:cancer_type",
         "subject_primary_disease": "path:primary_disease",
+        "subject_type_of_exposures" : "path:type_of_exposures",
         "data_source": "path:data_source",
         "commons_url": "externalgen3.prometheus.data-commons.org",
         "mc2dp_global_id": "path:mc2dp_global_id",


### PR DESCRIPTION
Link to Jira ticket if there is one: [MC2DP-346](https://ctds-planx.atlassian.net/browse/MC2DP-346?atlOrigin=eyJpIjoiYTUwYTNmYTY4NzNkNDlmYmE2NjA1YTUyZTQ0MjI3NmMiLCJwIjoiaiJ9)

### Environments
[qa-prometheus](https://qa-prometheus.planx-pla.net/)

### Description of changes
- added new `aggregated-subject-level-metadata` to aggmds
- **Notes:** 
    - This doesn't have fields for race, gender, ethnicity, and cancer grade, so that it won't reflect on the current graphs
    - field data source will have comma-separated entry now, which denotes all the sources the data is coming from; for example, if data is coming from GDC and VPODC, the output will be GDC, VPODC
    - The subject ID will be an array now, denoting all the IDs like APOLLO and UCHICAGO that the subject would have
    - `primary_disease` and `cancer_type` would also have comma-separated entries (if the team wants something else for this, we can discuss)
    - The new field `data_files` will have a list of all file information related to the subject
    - added new `subject_type_of_exposures` even though we have `subject_type_of_exposure` because the new exposures are an array of JSON objects, whereas the older one was a string
    - 

[MC2DP-346]: https://ctds-planx.atlassian.net/browse/MC2DP-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ