### PR TITLE
update qa brh tutorial ws image

### DIFF
--- a/qa-brh.planx-pla.net/manifests/hatchery/hatchery.json
+++ b/qa-brh.planx-pla.net/manifests/hatchery/hatchery.json
@@ -71,7 +71,7 @@
       "cpu-limit": "2.0",
       "memory-limit": "16Gi",
       "name": "(Tutorials) Example Analysis Jupyter Lab Notebooks",
-      "image": "quay.io/cdis/brh-notebooks:combined_demos__8c8c45ded1964148365bf209cbbfb26f72448d3d",
+      "image": "quay.io/cdis/brh-notebooks:combined_demos__48a3c0fc485db9b680a77b9da45a375a297a85fb",
       "env": {
         "FRAME_ANCESTORS": "https://qa-brh.planx-pla.net"
       },


### PR DESCRIPTION
Link to Jira ticket if there is one:

### Environments
QA BRH

### Description of changes
Updating the tutorial workspace image
- removing OADC notebook that is no longer working 
- update base image to jupyter-superslim-rkernel:2.1.0